### PR TITLE
Set message Message datacoding to plain

### DIFF
--- a/api/src/main/java/com/messagebird/objects/Message.java
+++ b/api/src/main/java/com/messagebird/objects/Message.java
@@ -27,7 +27,7 @@ public class Message implements MessageBase, Serializable {
     private Integer validity;
     private Integer gateway;
     private Map<String, Object> typeDetails;
-    private DataCodingType datacoding = DataCodingType.unicode;
+    private DataCodingType datacoding = DataCodingType.plain;
     private MClassType mclass;
     private Date scheduledDatetime;
 

--- a/api/src/test/java/com/messagebird/MessageBirdClientTest.java
+++ b/api/src/test/java/com/messagebird/MessageBirdClientTest.java
@@ -112,7 +112,7 @@ public class MessageBirdClientTest {
         assertTrue(mr.getId() != null);
         assertTrue(mr.getReference().equals(reference));
         assertTrue(mr.getBody().equals(body));
-        assertTrue(mr.getDatacoding().equals(DataCodingType.unicode));
+        assertTrue(mr.getDatacoding().equals(DataCodingType.plain));
 
         // Deleting of a message is not yet supported in test mode
         // Thread.sleep(1000);


### PR DESCRIPTION
For SMS messages the default datacoding should be plain. Unicode datacoding limits number of characters in the actual SMS message. All our other rest api libraries also have plain datacoding as default.