### PR TITLE
fix accept header

### DIFF
--- a/api/src/main/java/com/messagebird/MessageBirdServiceImpl.java
+++ b/api/src/main/java/com/messagebird/MessageBirdServiceImpl.java
@@ -153,7 +153,7 @@ public class MessageBirdServiceImpl implements MessageBirdService {
             connection = (HttpURLConnection) restService.openConnection();
         }
         connection.setDoInput(true);
-        connection.setRequestProperty("Accepts:", "application/json");
+        connection.setRequestProperty("Accept", "application/json");
         connection.setUseCaches(false);
         connection.setRequestProperty("charset", "utf-8");
         connection.setRequestProperty("Connection", "close");


### PR DESCRIPTION
The current version causes the following exception when using openjdk 1.8.0_66:
```
IllegalArgumentException: Illegal character(s) in message header field: Accepts:

Stacktrace (most recent call first):

    at sun.net.www.protocol.http.HttpURLConnection.checkMessageHeader
    at sun.net.www.protocol.http.HttpURLConnection.isExternalMessageHeaderAllowed
    at sun.net.www.protocol.http.HttpURLConnection.setRequestProperty
    at sun.net.www.protocol.https.HttpsURLConnectionImpl.setRequestProperty
    at com.messagebird.MessageBirdServiceImpl.getConnection
    at com.messagebird.MessageBirdServiceImpl.getJsonData
    at com.messagebird.MessageBirdServiceImpl.sendPayLoad
    at com.messagebird.MessageBirdClient.sendMessage
```

```
openjdk version "1.8.0_66-internal"
OpenJDK Runtime Environment (build 1.8.0_66-internal-b17)
OpenJDK 64-Bit Server VM (build 25.66-b17, mixed mode)
```
