### PR TITLE
Set the Content-Type header to text/plain for GET, DELETE requests

### DIFF
--- a/api/src/main/java/com/messagebird/MessageBirdServiceImpl.java
+++ b/api/src/main/java/com/messagebird/MessageBirdServiceImpl.java
@@ -186,11 +186,11 @@ public class MessageBirdServiceImpl implements MessageBirdService {
             // could have just used rquestType as it is
             connection.setDoOutput(false);
             connection.setRequestMethod("DELETE");
-            connection.setRequestProperty("Content-Type", "application/text");
+            connection.setRequestProperty("Content-Type", "text/plain");
         } else {
             connection.setDoOutput(false);
             connection.setRequestMethod("GET");
-            connection.setRequestProperty("Content-Type", "application/text");
+            connection.setRequestProperty("Content-Type", "text/plain");
         }
 
         return connection;


### PR DESCRIPTION
The type 'application/text' is not a valid mime-type.