### PR TITLE
Add support for the Lookup API

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ To try out the command line examples follow the above build instructions.
 When everything did build successful you can try out the API like this:
 ```shell
 cd examples/target
-java -cp examples-2.0.0-jar-with-dependencies.jar ExampleSendMessage test_gshuPaZoeEG6ovbc8M79w0QyM 31612345678 "This is a test message"
+java -cp examples-1.2.0-jar-with-dependencies.jar ExampleSendMessage test_gshuPaZoeEG6ovbc8M79w0QyM 31612345678 "This is a test message"
 ```
 
 Please see the other examples for a complete overview of all the available API calls.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ If you are using maven simply add the messagebird API to your dependencies like 
 <dependency>
     <groupId>com.messagebird</groupId>
     <artifactId>messagebird-api</artifactId>
-    <version>1.1.0</version>
+    <version>1.2.0</version>
 </dependency>
 ```
 
@@ -36,7 +36,7 @@ In case you are building without maven you still need maven to build the librari
 then simply copy the following jar's over to your project
 
 ```
-messagebird-api-1.1.0.jar
+messagebird-api-1.2.0.jar
 jackson-core-2.1.1.jar
 jackson-databind-2.1.1.jar
 jackson-mapper-asl-1.9.13.jar

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.messagebird</groupId>
     <artifactId>messagebird-api</artifactId>
-    <version>1.1.0</version>
+    <version>1.2.0</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>

--- a/api/src/main/java/com/messagebird/MessageBirdClient.java
+++ b/api/src/main/java/com/messagebird/MessageBirdClient.java
@@ -32,6 +32,8 @@ public class MessageBirdClient {
     private static final String MESSAGESPATH = "/messages";
     private static final String VOICEMESSAGESPATH = "/voicemessages";
     private static final String VERIFYPATH = "/verify";
+    private static final String LOOKUPPATH = "/lookup";
+    private static final String LOOKUPHLRPATH = "/lookup/%s/hlr";
     private MessageBirdService messageBirdService;
 
     public MessageBirdClient(final MessageBirdService messageBirdService) {
@@ -384,5 +386,125 @@ public class MessageBirdClient {
             throw new IllegalArgumentException("ID cannot be empty for verify");
         }
         messageBirdService.deleteByID(VERIFYPATH, id);
+    }
+
+    /**
+     * Send a Lookup request
+     *
+     * @param Lookup
+     * @return Lookup
+     * @throws UnauthorizedException
+     * @throws GeneralException
+     * @throws NotFoundException
+     */
+    public Lookup viewLookup(final Lookup lookup) throws UnauthorizedException, GeneralException, NotFoundException {
+        if (lookup.getPhoneNumber() == null) {
+            throw new IllegalArgumentException("Phonenumber must be specified.");
+        }
+        final Map<String, Object> params = new LinkedHashMap<String, Object>();
+        if (lookup.getCountryCode() != null) {
+            params.put("countryCode", lookup.getCountryCode());
+        }
+        return messageBirdService.requestByID(LOOKUPPATH, String.valueOf(lookup.getPhoneNumber()), params, Lookup.class);
+    }
+
+    /**
+     * Send a Lookup request
+     *
+     * @param phonenumber
+     * @return Lookup
+     * @throws UnauthorizedException
+     * @throws GeneralException
+     */
+    public Lookup viewLookup(final BigInteger phonenumber) throws UnauthorizedException, GeneralException, NotFoundException {
+        if (phonenumber == null) {
+            throw new IllegalArgumentException("Phonenumber must be specified.");
+        }
+        final Lookup lookup = new Lookup(phonenumber);
+        return this.viewLookup(lookup);
+    }
+
+    /**
+     * Request a Lookup HLR (lookup)
+     *
+     * @param LookupHlr
+     * @return lookupHlr
+     * @throws UnauthorizedException
+     * @throws GeneralException
+     */
+    public LookupHlr requestLookupHlr(final LookupHlr lookupHlr) throws UnauthorizedException, GeneralException {
+        if (lookupHlr.getPhoneNumber() == null) {
+            throw new IllegalArgumentException("Phonenumber must be specified.");
+        }
+        if (lookupHlr.getReference() == null) {
+            throw new IllegalArgumentException("Reference must be specified.");
+        }
+        final Map<String, Object> payload = new LinkedHashMap<String, Object>();
+        payload.put("phoneNumber", lookupHlr.getPhoneNumber());
+        payload.put("reference", lookupHlr.getReference());
+        if (lookupHlr.getCountryCode() != null) {
+            payload.put("countryCode", lookupHlr.getCountryCode());
+        }
+        return messageBirdService.sendPayLoad(String.format(LOOKUPHLRPATH, lookupHlr.getPhoneNumber()), payload, LookupHlr.class);
+    }
+
+    /**
+     * Request a Lookup HLR (lookup)
+     *
+     * @param phonenumber
+     * @param reference
+     * @return lookupHlr
+     * @throws UnauthorizedException
+     * @throws GeneralException
+     */
+    public LookupHlr requestLookupHlr(final BigInteger phonenumber, final String reference) throws UnauthorizedException, GeneralException {
+        if (phonenumber == null) {
+            throw new IllegalArgumentException("Phonenumber must be specified.");
+        }
+        if (reference == null) {
+            throw new IllegalArgumentException("Reference must be specified.");
+        }
+        final LookupHlr lookupHlr = new LookupHlr();
+        lookupHlr.setPhoneNumber(phonenumber);
+        lookupHlr.setReference(reference);
+        return this.requestLookupHlr(lookupHlr);
+    }
+
+    /**
+     * View a Lookup HLR (lookup)
+     *
+     * @param LookupHlr
+     * @return LookupHlr
+     * @throws UnauthorizedException
+     * @throws GeneralException
+     * @throws NotFoundException
+     */
+    public LookupHlr viewLookupHlr(final LookupHlr lookupHlr) throws UnauthorizedException, GeneralException, NotFoundException {
+        if (lookupHlr.getPhoneNumber() == null) {
+            throw new IllegalArgumentException("Phonenumber must be specified");
+        }
+        final Map<String, Object> params = new LinkedHashMap<String, Object>();
+        if (lookupHlr.getCountryCode() != null) {
+            params.put("countryCode", lookupHlr.getCountryCode());
+        }
+        return messageBirdService.requestByID(String.format(LOOKUPHLRPATH, lookupHlr.getPhoneNumber()), "", params, LookupHlr.class);
+    }
+
+    /**
+     * View a Lookup HLR (lookup)
+     *
+     * @param phonenumber
+     * @return LookupHlr
+     * @throws UnauthorizedException
+     * @throws GeneralException
+     * @throws NotFoundException
+     */
+    public LookupHlr viewLookupHlr(final BigInteger phonenumber) throws UnauthorizedException, GeneralException, NotFoundException {
+        if (phonenumber == null) {
+            throw new IllegalArgumentException("Phonenumber must be specified");
+        }
+        final LookupHlr lookupHlr = new LookupHlr();
+        lookupHlr.setPhoneNumber(phonenumber);
+        return this.viewLookupHlr(lookupHlr);
     }
 }

--- a/api/src/main/java/com/messagebird/MessageBirdServiceImpl.java
+++ b/api/src/main/java/com/messagebird/MessageBirdServiceImpl.java
@@ -32,7 +32,7 @@ public class MessageBirdServiceImpl implements MessageBirdService {
     private static final List<String> REQUESTMETHODS = Arrays.asList(new String[]{"GET", "POST", "DELETE"});
     private final String accessKey;
     private final String serviceUrl = "https://rest.messagebird.com";
-    private final String clientVersion = "1.1.0";
+    private final String clientVersion = "1.2.0";
     private final String userAgentString = "MessageBird/Java ApiClient/" + clientVersion;
     private Proxy proxy = null;
 
@@ -65,7 +65,7 @@ public class MessageBirdServiceImpl implements MessageBirdService {
         if (id != null) {
             path = "/" + id;
         }
-        // Make rest of get request
+        // Make rest of GET request
         String queryParams = "";
         if (!params.isEmpty()) {
             queryParams = "?" + getPathVariables(params);

--- a/api/src/main/java/com/messagebird/objects/Hlr.java
+++ b/api/src/main/java/com/messagebird/objects/Hlr.java
@@ -14,9 +14,9 @@ import java.util.Date;
 public class Hlr {
     private String id;
     private String href;
-    private BigInteger msisdn;
+    protected BigInteger msisdn;
     private String network;
-    private String reference;
+    protected String reference;
     private String status;
     private Date createdDatetime;
     private Date statusDatetime;

--- a/api/src/main/java/com/messagebird/objects/Lookup.java
+++ b/api/src/main/java/com/messagebird/objects/Lookup.java
@@ -1,0 +1,108 @@
+package com.messagebird.objects;
+
+import java.io.Serializable;
+import java.math.BigInteger;
+
+public class Lookup implements Serializable {
+
+    private static final long serialVersionUID = 8927014359452296030L;
+
+    private String href;
+    private String countryCode;
+    private Integer countryPrefix;
+    private BigInteger phoneNumber;
+    private String type;
+    private Formats formats;
+    private LookupHlr hlr;
+
+    @Override
+    public String toString() {
+        return "Lookup{" +
+                "href=" + href +
+                ", countryCode=" + countryCode +
+                ", countryPrefix=" + countryPrefix +
+                ", phoneNumber=" + phoneNumber +
+                ", type=" + type +
+                ", formats=" + formats +
+                ", hlr=" + hlr +
+                "}";
+    }
+
+    public Lookup() {
+    }
+
+    public Lookup(BigInteger phoneNumber) {
+        this.phoneNumber = phoneNumber;
+    }
+
+    public String getHref() {
+        return href;
+    }
+
+    public String getCountryCode() {
+        return countryCode;
+    }
+
+    public void setCountryCode(String countryCode) {
+        this.countryCode = countryCode;
+    }
+
+    public Integer getCountryPrefix() {
+        return countryPrefix;
+    }
+
+    public BigInteger getPhoneNumber() {
+        return phoneNumber;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public Formats getFormats() {
+        return formats;
+    }
+
+    public Hlr getHlr() {
+        return hlr;
+    }
+
+    static public class Formats implements Serializable {
+
+        private static final long serialVersionUID = 2165916336570704972L;
+
+        private String e164;
+        private String international;
+        private String national;
+        private String rfc3966;
+
+        public Formats() {
+        }
+
+        @Override
+        public String toString() {
+            return "Formats{" +
+                    "e164=" + e164 +
+                    ", international=" + international +
+                    ", national=" + national +
+                    ", rfc3966=" + rfc3966 +
+                    '}';
+        }
+
+        public String getE164() {
+            return e164;
+        }
+
+        public String getInternational() {
+            return international;
+        }
+
+        public String getNational() {
+            return national;
+        }
+
+        public String getRfc3966() {
+            return rfc3966;
+        }
+    }
+}

--- a/api/src/main/java/com/messagebird/objects/LookupHlr.java
+++ b/api/src/main/java/com/messagebird/objects/LookupHlr.java
@@ -1,0 +1,27 @@
+package com.messagebird.objects;
+
+import java.math.BigInteger;
+
+public class LookupHlr extends Hlr {
+    private String countryCode;
+
+    public String getCountryCode() {
+        return countryCode;
+    }
+
+    public void setCountryCode(String countryCode) {
+        this.countryCode = countryCode;
+    }
+
+    public BigInteger getPhoneNumber() {
+        return msisdn;
+    }
+
+    public void setPhoneNumber(BigInteger phoneNumber) {
+        this.msisdn = phoneNumber;
+    }
+
+    public void setReference(String reference) {
+        this.reference = reference;
+    }
+}

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.messagebird</groupId>
     <artifactId>examples</artifactId>
-    <version>1.0.1</version>
+    <version>1.2.0</version>
 
     <licenses>
         <license>
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>com.messagebird</groupId>
             <artifactId>messagebird-api</artifactId>
-            <version>1.1.0</version>
+            <version>1.2.0</version>
         </dependency>
     </dependencies>
 

--- a/examples/src/main/java/ExampleRequestLookupHlr.java
+++ b/examples/src/main/java/ExampleRequestLookupHlr.java
@@ -1,0 +1,50 @@
+import com.messagebird.MessageBirdClient;
+import com.messagebird.MessageBirdService;
+import com.messagebird.MessageBirdServiceImpl;
+import com.messagebird.exceptions.NotFoundException;
+import com.messagebird.exceptions.GeneralException;
+import com.messagebird.exceptions.UnauthorizedException;
+import com.messagebird.objects.LookupHlr;
+
+import java.math.BigInteger;
+
+public class ExampleRequestLookupHlr {
+
+    public static void main(String[] args) {
+
+        if (args.length < 3) {
+            System.out.println("Please specify your access key, phone and reference in that order example : java -jar <this jar file> test_accesskey 31612345678 reference");
+            return;
+        }
+
+        // First create your service object
+        final MessageBirdService wsr = new MessageBirdServiceImpl(args[0]);
+
+        // Add the service to the client
+        final MessageBirdClient messageBirdClient = new MessageBirdClient(wsr);
+
+        try {
+            // Request Lookup HLR
+            System.out.println("Requesting Lookup HLR:");
+            final LookupHlr lookupHlrRequest = new LookupHlr();
+            lookupHlrRequest.setPhoneNumber(new BigInteger(args[1]));
+            lookupHlrRequest.setReference(args[2]);
+            // Optionally set a country code (in the case of national numbers)
+            if (args.length > 3 && args[3] != null && !args[3].isEmpty()) {
+                lookupHlrRequest.setCountryCode(args[3]);
+            }
+            final LookupHlr lookupHlr = messageBirdClient.requestLookupHlr(lookupHlrRequest);
+            System.out.println(lookupHlr.toString());
+        } catch (UnauthorizedException unauthorized) {
+            if (unauthorized.getErrors()!=null) {
+                System.out.println(unauthorized.getErrors().toString());
+            }
+            unauthorized.printStackTrace();
+        } catch (GeneralException generalException) {
+            if (generalException.getErrors() !=null) {
+                System.out.println(generalException.getErrors().toString());
+            }
+            generalException.printStackTrace();
+        }
+    }
+}

--- a/examples/src/main/java/ExampleViewLookup.java
+++ b/examples/src/main/java/ExampleViewLookup.java
@@ -1,0 +1,53 @@
+import com.messagebird.MessageBirdClient;
+import com.messagebird.MessageBirdService;
+import com.messagebird.MessageBirdServiceImpl;
+import com.messagebird.exceptions.NotFoundException;
+import com.messagebird.exceptions.GeneralException;
+import com.messagebird.exceptions.UnauthorizedException;
+import com.messagebird.objects.Lookup;
+
+import java.math.BigInteger;
+
+public class ExampleViewLookup {
+
+    public static void main(String[] args) {
+
+        if (args.length < 2) {
+            System.out.println("Please specify your access key and phone in that order example : java -jar <this jar file> test_accesskey 31612345678");
+            return;
+        }
+
+        // First create your service object
+        final MessageBirdService wsr = new MessageBirdServiceImpl(args[0]);
+
+        // Add the service to the client
+        final MessageBirdClient messageBirdClient = new MessageBirdClient(wsr);
+
+        try {
+            // View Lookup
+            System.out.println("Viewing Lookup:");
+            final Lookup lookupRequest = new Lookup(new BigInteger(args[1]));
+            // Optionally set a country code (in the case of national numbers)
+            if (args.length > 2 && args[2] != null && !args[2].isEmpty()) {
+                lookupRequest.setCountryCode(args[2]);
+            }
+            final Lookup lookup = messageBirdClient.viewLookup(lookupRequest);
+            System.out.println(lookup.toString());
+        } catch (UnauthorizedException unauthorized) {
+            if (unauthorized.getErrors()!=null) {
+                System.out.println(unauthorized.getErrors().toString());
+            }
+            unauthorized.printStackTrace();
+        } catch (GeneralException generalException) {
+            if (generalException.getErrors() !=null) {
+                System.out.println(generalException.getErrors().toString());
+            }
+            generalException.printStackTrace();
+        } catch (NotFoundException notFoundException) {
+            if (notFoundException.getErrors() !=null) {
+                System.out.println(notFoundException.getErrors().toString());
+            }
+            notFoundException.printStackTrace();
+        }
+    }
+}

--- a/examples/src/main/java/ExampleViewLookupHlr.java
+++ b/examples/src/main/java/ExampleViewLookupHlr.java
@@ -1,0 +1,54 @@
+import com.messagebird.MessageBirdClient;
+import com.messagebird.MessageBirdService;
+import com.messagebird.MessageBirdServiceImpl;
+import com.messagebird.exceptions.NotFoundException;
+import com.messagebird.exceptions.GeneralException;
+import com.messagebird.exceptions.UnauthorizedException;
+import com.messagebird.objects.LookupHlr;
+
+import java.math.BigInteger;
+
+public class ExampleViewLookupHlr {
+
+    public static void main(String[] args) {
+
+        if (args.length < 2) {
+            System.out.println("Please specify your access key and phone in that order example : java -jar <this jar file> test_accesskey 31612345678");
+            return;
+        }
+
+        // First create your service object
+        final MessageBirdService wsr = new MessageBirdServiceImpl(args[0]);
+
+        // Add the service to the client
+        final MessageBirdClient messageBirdClient = new MessageBirdClient(wsr);
+
+        try {
+            // View Lookup HLR
+            System.out.println("Viewing Lookup HLR:");
+            final LookupHlr lookupHlrRequest = new LookupHlr();
+            lookupHlrRequest.setPhoneNumber(new BigInteger(args[1]));
+            // Optionally set a country code (in the case of national numbers)
+            if (args.length > 2 && args[2] != null && !args[2].isEmpty()) {
+                lookupHlrRequest.setCountryCode(args[2]);
+            }
+            final LookupHlr lookupHlr = messageBirdClient.viewLookupHlr(lookupHlrRequest);
+            System.out.println(lookupHlr.toString());
+        } catch (UnauthorizedException unauthorized) {
+            if (unauthorized.getErrors()!=null) {
+                System.out.println(unauthorized.getErrors().toString());
+            }
+            unauthorized.printStackTrace();
+        } catch (GeneralException generalException) {
+            if (generalException.getErrors() !=null) {
+                System.out.println(generalException.getErrors().toString());
+            }
+            generalException.printStackTrace();
+        } catch (NotFoundException notFoundException) {
+            if (notFoundException.getErrors() !=null) {
+                System.out.println(notFoundException.getErrors().toString());
+            }
+            notFoundException.printStackTrace();
+        }
+    }
+}


### PR DESCRIPTION
Every method is added twice, one with the required object, and one with only required parameters.

Version is bumped to 1.2.0 for new functionality.

Version is also bumped for the examples. Bumped to 1.2.0 (instead of 1.1.0) as it should've been bumped when the Verify API was added in a previous pull request.