### PR TITLE
Explicitly state we do not want to skip tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 dist: trusty
 before_script: cd api/
-script: mvn test -Ptest -Dhttps.protocols=TLSv1.2 -DmessageBirdAccessKey=test_iQpAp0KCs5GCsMpDhIx2leuNB -DmessageBirdMSISDN=31612345678
+script: mvn test -Ptest -DskipTests=false -Dhttps.protocols=TLSv1.2 -DmessageBirdAccessKey=test_iQpAp0KCs5GCsMpDhIx2leuNB -DmessageBirdMSISDN=31612345678
 jdk:
   - oraclejdk8
   - oraclejdk9


### PR DESCRIPTION
This PR explicitly tells Travis to not skip running tests. Not doing so resulted in inconsistent behaviour across versions.