### PR TITLE
Disable automatic releasing.

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -218,7 +218,7 @@
                 <configuration>
                     <serverId>ossrh</serverId>
                     <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                    <autoReleaseAfterClose>false</autoReleaseAfterClose>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
By setting autoReleaseAfterClose to false, ossrh does not automatically
release newly staged artifacts to Maven Central. This allows us to
manually inspect them in the staging environment.