### PR TITLE
Add a dedicated VerifyType enum.

### DIFF
--- a/api/src/main/java/com/messagebird/objects/VerifyRequest.java
+++ b/api/src/main/java/com/messagebird/objects/VerifyRequest.java
@@ -10,7 +10,7 @@ public class VerifyRequest implements Serializable {
     private String recipient;
     private String originator;
     private String reference;
-    private MsgType type;
+    private VerifyType type;
     private DataCodingType datacoding = DataCodingType.plain;
     private String template;
     private Integer timeout;
@@ -46,11 +46,11 @@ public class VerifyRequest implements Serializable {
         this.reference = reference;
     }
 
-    public MsgType getType() {
+    public VerifyType getType() {
         return type;
     }
 
-    public void setType(MsgType type) {
+    public void setType(VerifyType type) {
         this.type = type;
     }
 

--- a/api/src/main/java/com/messagebird/objects/VerifyType.java
+++ b/api/src/main/java/com/messagebird/objects/VerifyType.java
@@ -1,0 +1,31 @@
+package com.messagebird.objects;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Determines which type the message will be.
+ */
+public enum VerifyType {
+
+    FLASH("flash"),
+    SMS("sms"),
+    TTS("tts");
+
+    final String value;
+
+    VerifyType(String type) {
+        this.value = type;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return "VerifyType{" +
+                "value='" + value + '\'' +
+                '}';
+    }
+}

--- a/api/src/test/java/com/messagebird/MessageBirdClientTest.java
+++ b/api/src/test/java/com/messagebird/MessageBirdClientTest.java
@@ -319,7 +319,7 @@ public class MessageBirdClientTest {
         verifyRequest.setOriginator("Code");
         verifyRequest.setReference(reference);
         verifyRequest.setLanguage(Language.NL_NL);
-        verifyRequest.setType(MsgType.sms);
+        verifyRequest.setType(VerifyType.SMS);
         verifyRequest.setTimeout(30);
         verifyRequest.setTokenLength(6);
         verifyRequest.setVoice(Gender.FEMALE);

--- a/api/src/test/java/com/messagebird/VerifyTest.java
+++ b/api/src/test/java/com/messagebird/VerifyTest.java
@@ -1,0 +1,57 @@
+package com.messagebird;
+
+import com.messagebird.exceptions.GeneralException;
+import com.messagebird.exceptions.UnauthorizedException;
+import com.messagebird.objects.Verify;
+import com.messagebird.objects.VerifyRequest;
+import com.messagebird.objects.VerifyType;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+public class VerifyTest {
+
+    private static final String VERIFY_SMS_RESPONSE = "{\"id\": \"verify-id-sms\",\"href\": \"https://rest.messagebird.com/verify/verify-id-sms\",\"recipient\": 31612345678,\"reference\": null,\"messages\": {\"href\": \"https://rest.messagebird.com/messages/5958c0d5e2df41de8154e5e88bfeb5bc\"},\"status\": \"sent\",\"createdDatetime\": \"2018-09-25T14:38:12+00:00\",\"validUntilDatetime\": \"2018-09-25T14:38:42+00:00\"}";
+    private static final String VERIFY_TTS_RESPONSE = "{\"id\": \"verify-id-tts\",\"href\": \"https://rest.messagebird.com/verify/verify-id-tts\",\"recipient\": 31612345678,\"reference\": null,\"messages\": {\"href\": \"https://rest.messagebird.com/voicemessages/c043ab473f8e4f2590ab9a16d25f2899\"},\"status\": \"sent\",\"createdDatetime\": \"2018-09-25T14:35:10+00:00\",\"validUntilDatetime\": \"2018-09-25T14:35:40+00:00\"}";
+
+    @Test
+    public void testSendVerifyTokenSms() throws GeneralException, UnauthorizedException {
+        VerifyRequest verifyRequest = new VerifyRequest("31612345678");
+        verifyRequest.setType(VerifyType.SMS);
+
+        MessageBirdService messageBirdService = SpyService
+                .expects("POST", "verify", verifyRequest)
+                .withRestAPIBaseURL()
+                .andReturns(new APIResponse(VERIFY_SMS_RESPONSE, 200));
+        MessageBirdClient messageBirdClient = new MessageBirdClient(messageBirdService);
+
+        Verify verify = messageBirdClient.sendVerifyToken(verifyRequest);
+
+        assertEquals("verify-id-sms", verify.getId());
+    }
+
+    @Test
+    public void testSendVerifyTokenTts() throws GeneralException, UnauthorizedException {
+        VerifyRequest verifyRequest = new VerifyRequest("31612345678");
+        verifyRequest.setType(VerifyType.TTS);
+
+        MessageBirdService messageBirdService = SpyService
+                .expects("POST", "verify", verifyRequest)
+                .withRestAPIBaseURL()
+                .andReturns(new APIResponse(VERIFY_TTS_RESPONSE, 200));
+        MessageBirdClient messageBirdClient = new MessageBirdClient(messageBirdService);
+
+        Verify verify = messageBirdClient.sendVerifyToken(verifyRequest);
+
+        assertEquals("verify-id-tts", verify.getId());
+    }
+
+    @Test
+    public void testVerifyTypeValue() {
+        // Important for generating proper JSON payloads...
+        assertEquals("flash", VerifyType.FLASH.getValue());
+        assertEquals("sms", VerifyType.SMS.getValue());
+        assertEquals("tts", VerifyType.TTS.getValue());
+    }
+}


### PR DESCRIPTION
Priorly we used MsgType, but that contains values not appropriate
for the Verify endpoint. It was also missing text to speech.