### PR TITLE
Override HttpURLConnection behaviour to allow PATCH requests.

### DIFF
--- a/api/src/main/java/com/messagebird/MessageBirdServiceImpl.java
+++ b/api/src/main/java/com/messagebird/MessageBirdServiceImpl.java
@@ -257,11 +257,13 @@ public class MessageBirdServiceImpl implements MessageBirdService {
             modifiersField.setAccessible(true);
             modifiersField.setInt(methodsField, methodsField.getModifiers() & ~Modifier.FINAL);
 
+            Object noInstanceBecauseStaticField = null;
+
             // Determine what methods should be allowed.
-            String[] allowedMethods = getAllowedMethods((String[]) methodsField.get(null));
+            String[] existingMethods = (String[]) methodsField.get(noInstanceBecauseStaticField);
+            String[] allowedMethods = getAllowedMethods(existingMethods);
 
             // Override the actual field to allow PATCH.
-            Object noInstanceBecauseStaticField = null;
             methodsField.set(noInstanceBecauseStaticField, allowedMethods);
 
             // Set flag so we only have to run this once.


### PR DESCRIPTION
Before, we relied on a server side hack (X-HTTP-Method-Override
header) to allow PATCH requests - which is normally not supported.
This is however something we'd like to avoid. Therefore we now use
reflection to make HttpURLConnection accept PATCH requests.