### PR TITLE
Adding getter to ConversationWebhookCreateRequest

### DIFF
--- a/api/src/main/java/com/messagebird/objects/conversations/ConversationWebhookCreateRequest.java
+++ b/api/src/main/java/com/messagebird/objects/conversations/ConversationWebhookCreateRequest.java
@@ -28,4 +28,8 @@ public class ConversationWebhookCreateRequest extends ConversationWebhookBaseReq
     protected String getStringRepresentationOfExtraParameters() {
         return "channelId='" + channelId;
     }
+
+    public String getChannelId() {
+        return channelId;
+    }
 }


### PR DESCRIPTION
Adding getter to ConversationWebhookCreateRequest as JSON parser doesn't pick up the channelId parameter otherwise