### PR TITLE
Unexpected 400 error when repeat option set in a call flow

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.messagebird</groupId>
     <artifactId>messagebird-api</artifactId>
-    <version>3.0.6</version> <!--
+    <version>3.0.7-SNAPSHOT</version> <!--
         are you going to bump a major number?
         then you are pleased to replace com.messagebird.Base64 with some library, for example net.iharder.base64
     -->
@@ -42,7 +42,7 @@
         <connection>scm:git:git@github.com:messagebird/java-rest-api.git</connection>
         <developerConnection>scm:git:git@github.com:messagebird/java-rest-api.git</developerConnection>
         <url>git@github.com:messagebird/java-rest-api.git</url>
-      <tag>messagebird-api-3.0.6</tag>
+      <tag>HEAD</tag>
     </scm>
 
     <profiles>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.messagebird</groupId>
     <artifactId>messagebird-api</artifactId>
-    <version>3.0.6-SNAPSHOT</version> <!--
+    <version>3.0.6</version> <!--
         are you going to bump a major number?
         then you are pleased to replace com.messagebird.Base64 with some library, for example net.iharder.base64
     -->
@@ -42,7 +42,7 @@
         <connection>scm:git:git@github.com:messagebird/java-rest-api.git</connection>
         <developerConnection>scm:git:git@github.com:messagebird/java-rest-api.git</developerConnection>
         <url>git@github.com:messagebird/java-rest-api.git</url>
-      <tag>HEAD</tag>
+      <tag>messagebird-api-3.0.6</tag>
     </scm>
 
     <profiles>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.messagebird</groupId>
     <artifactId>messagebird-api</artifactId>
-    <version>3.0.5</version> <!--
+    <version>3.0.6-SNAPSHOT</version> <!--
         are you going to bump a major number?
         then you are pleased to replace com.messagebird.Base64 with some library, for example net.iharder.base64
     -->

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.messagebird</groupId>
     <artifactId>messagebird-api</artifactId>
-    <version>3.0.7-SNAPSHOT</version> <!--
+    <version>3.0.6</version> <!--
         are you going to bump a major number?
         then you are pleased to replace com.messagebird.Base64 with some library, for example net.iharder.base64
     -->

--- a/api/src/main/java/com/messagebird/objects/VoiceStepOption.java
+++ b/api/src/main/java/com/messagebird/objects/VoiceStepOption.java
@@ -10,7 +10,7 @@ public class VoiceStepOption implements Serializable {
     private String payload;
     private String language;
     private String voice;
-    private String repeat;
+    private int repeat;
     private String media;
     private int length;
     private int maxLength;
@@ -57,11 +57,11 @@ public class VoiceStepOption implements Serializable {
         this.voice = voice;
     }
 
-    public String getRepeat() {
+    public int getRepeat() {
         return repeat;
     }
 
-    public void setRepeat(String repeat) {
+    public void setRepeat(int repeat) {
         this.repeat = repeat;
     }
 

--- a/api/src/test/java/com/messagebird/TestUtil.java
+++ b/api/src/test/java/com/messagebird/TestUtil.java
@@ -173,7 +173,7 @@ class TestUtil {
         voiceStepOption.setPayload("Test payload Update");
         voiceStepOption.setLanguage("en-US");
         voiceStepOption.setVoice("female");
-        voiceStepOption.setRepeat("5");
+        voiceStepOption.setRepeat(5);
         voiceStepOption.setMedia("test.wav");
         voiceStepOption.setLength(10);
         voiceStepOption.setMaxLength(20);

--- a/api/src/test/java/com/messagebird/VoiceCallFlowTest.java
+++ b/api/src/test/java/com/messagebird/VoiceCallFlowTest.java
@@ -236,7 +236,7 @@ public class VoiceCallFlowTest {
         assertEquals(voiceStepOption.getPayload(), "Test payload");
         assertEquals(voiceStepOption.getLanguage(), "en-GB");
         assertEquals(voiceStepOption.getVoice(), "male");
-        assertEquals(voiceStepOption.getRepeat(), "1");
+        assertEquals(voiceStepOption.getRepeat(), 1);
         assertEquals(voiceStepOption.getMedia(), "test.mp3");
         assertEquals(voiceStepOption.getFinishOnKey(), "1");
         assertEquals(voiceStepOption.getTranscribeLanguage(), "en-GB");

--- a/api/src/test/resources/fixtures/call_flow_update_response.json
+++ b/api/src/test/resources/fixtures/call_flow_update_response.json
@@ -12,7 +12,7 @@
             "payload"             : "Test payload",
             "language"            : "en-GB",
             "voice"               : "male",
-            "repeat"              : "1",
+            "repeat"              : 1,
             "media"               : "test.mp3",
             "length"              : 1,
             "maxLength"           : 2,

--- a/api/src/test/resources/fixtures/call_flow_view.json
+++ b/api/src/test/resources/fixtures/call_flow_view.json
@@ -12,7 +12,7 @@
             "payload"             : "Test payload",
             "language"            : "en-GB",
             "voice"               : "male",
-            "repeat"              : "1",
+            "repeat"              : 1,
             "media"               : "test.mp3",
             "length"              : 1,
             "maxLength"           : 2,

--- a/api/src/test/resources/fixtures/call_flows_list.json
+++ b/api/src/test/resources/fixtures/call_flows_list.json
@@ -12,7 +12,7 @@
             "payload"             : "Test payload",
             "language"            : "en-GB",
             "voice"               : "male",
-            "repeat"              : "1",
+            "repeat"              : 1,
             "media"               : "test.mp3",
             "length"              : 1,
             "maxLength"           : 2,

--- a/api/src/test/resources/fixtures/call_flows_post.json
+++ b/api/src/test/resources/fixtures/call_flows_post.json
@@ -12,7 +12,7 @@
             "payload"             : "Test payload",
             "language"            : "en-GB",
             "voice"               : "male",
-            "repeat"              : "1",
+            "repeat"              : 1,
             "media"               : "test.mp3",
             "length"              : 1,
             "maxLength"           : 2,

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.messagebird</groupId>
     <artifactId>examples</artifactId>
-    <version>3.0.5</version>
+    <version>3.0.6</version>
 
     <licenses>
         <license>


### PR DESCRIPTION
Fixes incorrect type (string->int) leading to a 400 error when trying to create a step with repeat set  in the step option of a call flow.