### PR TITLE
Numbers API Methods

### DIFF
--- a/api/src/main/java/com/messagebird/MessageBirdClient.java
+++ b/api/src/main/java/com/messagebird/MessageBirdClient.java
@@ -1601,14 +1601,13 @@ public class MessageBirdClient {
      * Checks whether a particular country code is a recognized ISO Country.
      *
      * @param countryCode The country code in which the Number should be purchased.
-     * @throws IllegalArgumentException
+     * @throws IllegalArgumentException for invalid country code
      */
-    private Boolean countryCodeIsValid(String countryCode) throws IllegalArgumentException {
-        final Boolean isValid = Arrays.asList(Locale.getISOCountries()).contains(countryCode);
+    private void countryCodeIsValid(String countryCode) throws IllegalArgumentException {
+        final boolean isValid = Arrays.asList(Locale.getISOCountries()).contains(countryCode);
         if (!isValid) {
             throw new IllegalArgumentException("Invalid Country Code Provided.");
         }
-        return true;
     }
 
     /**
@@ -1709,7 +1708,7 @@ public class MessageBirdClient {
     /**
      * Cancels a particular number.
      *
-     * @param nummber The number to cancel.
+     * @param number The number to cancel.
      * @throws GeneralException             general exception
      * @throws UnauthorizedException        if client is unauthorized
      * @throws NotFoundException            if the resource is missing

--- a/api/src/main/java/com/messagebird/MessageBirdClient.java
+++ b/api/src/main/java/com/messagebird/MessageBirdClient.java
@@ -64,6 +64,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -1597,14 +1598,30 @@ public class MessageBirdClient {
     }
 
     /**
+     * Checks whether a particular country code is a recognized ISO Country.
+     *
+     * @param countryCode The country code in which the Number should be purchased.
+     * @throws IllegalArgumentException
+     */
+    private Boolean countryCodeIsValid(String countryCode) throws IllegalArgumentException {
+        final Boolean isValid = Arrays.asList(Locale.getISOCountries()).contains(countryCode);
+        if (!isValid) {
+            throw new IllegalArgumentException("Invalid Country Code Provided.");
+        }
+        return true;
+    }
+
+    /**
      * Lists Numbers that are available to purchase in a particular country code, without any filters.
      *
      * @param countryCode The country code in which the Number should be purchased.
      * @throws GeneralException             general exception
      * @throws UnauthorizedException        if client is unauthorized
      * @throws NotFoundException            if the resource is missing
+     * @throws IllegalArgumentException     if the country code provided is invalid
      */
-    public PhoneNumbersResponse listNumbersForPurchase(String countryCode) throws GeneralException, UnauthorizedException, NotFoundException {
+    public PhoneNumbersResponse listNumbersForPurchase(String countryCode) throws GeneralException, UnauthorizedException, NotFoundException, IllegalArgumentException {
+        countryCodeIsValid(countryCode);
         final String url = String.format("%s/available-phone-numbers", NUMBERS_CALLS_BASE_URL);
         return messageBirdService.requestByID(url, countryCode, PhoneNumbersResponse.class);
     }
@@ -1617,8 +1634,10 @@ public class MessageBirdClient {
      * @throws GeneralException             general exception
      * @throws UnauthorizedException        if client is unauthorized
      * @throws NotFoundException            if the resource is missing
+     * @throws IllegalArgumentException     if the country code provided is invalid
      */
-    public PhoneNumbersResponse listNumbersForPurchase(String countryCode, PhoneNumbersLookup params) throws GeneralException, UnauthorizedException, NotFoundException {
+    public PhoneNumbersResponse listNumbersForPurchase(String countryCode, PhoneNumbersLookup params) throws GeneralException, UnauthorizedException, NotFoundException, IllegalArgumentException {
+        countryCodeIsValid(countryCode);
         final String url = String.format("%s/available-phone-numbers", NUMBERS_CALLS_BASE_URL);
         return messageBirdService.requestByID(url, countryCode, params.toHashMap(), PhoneNumbersResponse.class);
     }
@@ -1630,13 +1649,17 @@ public class MessageBirdClient {
      * @param countryCode   The country code in which the Number should be purchased.
      * @throws GeneralException             general exception
      * @throws UnauthorizedException        if client is unauthorized
+     * @throws IllegalArgumentException     if the country code provided is invalid
      */
-    public PurchasedNumberCreatedResponse purchaseNumber(String number, String countryCode, int billingIntervalMonths) throws UnauthorizedException, GeneralException {
+    public PurchasedNumberCreatedResponse purchaseNumber(String number, String countryCode, int billingIntervalMonths) throws UnauthorizedException, GeneralException, IllegalArgumentException {
+        countryCodeIsValid(countryCode);
         final String url = String.format("%s/phone-numbers", NUMBERS_CALLS_BASE_URL);
-
         final Map<String, Object> payload = new LinkedHashMap<String, Object>();
         payload.put("number", number);
         payload.put("countryCode", countryCode);
+        if (!Arrays.asList(1, 3, 6, 9).contains(billingIntervalMonths)) {
+            throw new IllegalArgumentException("Billing Interval Must Be Either 1, 3, 6, or 9.");
+        }
         payload.put("billingIntervalMonths", billingIntervalMonths);
 
         return messageBirdService.sendPayLoad(url, payload, PurchasedNumberCreatedResponse.class);

--- a/api/src/main/java/com/messagebird/MessageBirdClient.java
+++ b/api/src/main/java/com/messagebird/MessageBirdClient.java
@@ -1607,4 +1607,9 @@ public class MessageBirdClient {
         payload.put("tags", Arrays.asList(tags));
         return messageBirdService.sendPayLoad("PATCH", url, payload, PurchasedNumbersResponse.class);
     }
+
+    public void cancelNumber(String number) throws UnauthorizedException, GeneralException, NotFoundException {
+        final String url = String.format("%s/v1/phone-numbers", NUMBERS_CALLS_BASE_URL);
+        messageBirdService.deleteByID(url, number);
+    }
 } 

--- a/api/src/main/java/com/messagebird/MessageBirdClient.java
+++ b/api/src/main/java/com/messagebird/MessageBirdClient.java
@@ -22,6 +22,7 @@ import com.messagebird.objects.PagedPaging;
 import com.messagebird.objects.PhoneNumber;
 import com.messagebird.objects.PhoneNumberFeature;
 import com.messagebird.objects.PhoneNumbersResponse;
+import com.messagebird.objects.PurchasedPhoneNumber;
 import com.messagebird.objects.Verify;
 import com.messagebird.objects.VerifyRequest;
 import com.messagebird.objects.VoiceMessage;
@@ -1609,4 +1610,14 @@ public class MessageBirdClient {
         return messageBirdService.requestByID(url, countryCode, params, PhoneNumbersResponse.class);
     }
 
+    public PurchasedPhoneNumber purchaseNumber(String number, String countryCode, int billingIntervalMonths) throws UnauthorizedException, GeneralException {
+        final String url = String.format("%s/v1/phone-numbers", NUMBERS_CALLS_BASE_URL);
+
+        final Map<String, Object> payload = new LinkedHashMap<String, Object>();
+        payload.put("number", number);
+        payload.put("countryCode", countryCode);
+        payload.put("billingIntervalMonths", billingIntervalMonths);
+
+        return messageBirdService.sendPayLoad(url, payload, PurchasedPhoneNumber.class);
+    }
 } 

--- a/api/src/main/java/com/messagebird/MessageBirdClient.java
+++ b/api/src/main/java/com/messagebird/MessageBirdClient.java
@@ -3,7 +3,33 @@ package com.messagebird;
 import com.messagebird.exceptions.GeneralException;
 import com.messagebird.exceptions.NotFoundException;
 import com.messagebird.exceptions.UnauthorizedException;
-import com.messagebird.objects.*;
+import com.messagebird.objects.Balance;
+import com.messagebird.objects.Contact;
+import com.messagebird.objects.ContactList;
+import com.messagebird.objects.ContactRequest;
+import com.messagebird.objects.ErrorReport;
+import com.messagebird.objects.Group;
+import com.messagebird.objects.GroupList;
+import com.messagebird.objects.GroupRequest;
+import com.messagebird.objects.Hlr;
+import com.messagebird.objects.Lookup;
+import com.messagebird.objects.LookupHlr;
+import com.messagebird.objects.Message;
+import com.messagebird.objects.MessageList;
+import com.messagebird.objects.MessageResponse;
+import com.messagebird.objects.MsgType;
+import com.messagebird.objects.PagedPaging;
+import com.messagebird.objects.PhoneNumbersLookup;
+import com.messagebird.objects.PhoneNumbersResponse;
+import com.messagebird.objects.PurchasedNumber;
+import com.messagebird.objects.PurchasedNumberCreatedResponse;
+import com.messagebird.objects.PurchasedNumbersResponse;
+import com.messagebird.objects.PurchasedNumbersFilter;
+import com.messagebird.objects.Verify;
+import com.messagebird.objects.VerifyRequest;
+import com.messagebird.objects.VoiceMessage;
+import com.messagebird.objects.VoiceMessageList;
+import com.messagebird.objects.VoiceMessageResponse;
 import com.messagebird.objects.conversations.Conversation;
 import com.messagebird.objects.conversations.ConversationList;
 import com.messagebird.objects.conversations.ConversationMessage;
@@ -68,7 +94,7 @@ public class MessageBirdClient {
     private static final String BASE_URL_CONVERSATIONS_WHATSAPP_SANDBOX = "https://whatsapp-sandbox.messagebird.com/v1";
     
     static final String VOICE_CALLS_BASE_URL = "https://voice.messagebird.com";
-    static final String NUMBERS_CALLS_BASE_URL = "https://numbers.messagebird.com";
+    static final String NUMBERS_CALLS_BASE_URL = "https://numbers.messagebird.com/v1";
     private static String[] supportedLanguages = {"de-DE", "en-AU", "en-UK", "en-US", "es-ES", "es-LA", "fr-FR", "it-IT", "nl-NL", "pt-BR"};
 
     private static final String BALANCEPATH = "/balance";
@@ -1570,18 +1596,43 @@ public class MessageBirdClient {
         }
     }
 
-    public PhoneNumbersResponse listNumbersForPurchase(String countryCode) throws IllegalArgumentException, GeneralException, UnauthorizedException, NotFoundException {
-        final String url = String.format("%s/v1/available-phone-numbers", NUMBERS_CALLS_BASE_URL);
+    /**
+     * Lists Numbers that are available to purchase in a particular country code, without any filters.
+     *
+     * @param countryCode The country code in which the Number should be purchased.
+     * @throws GeneralException             general exception
+     * @throws UnauthorizedException        if client is unauthorized
+     * @throws NotFoundException            if the resource is missing
+     */
+    public PhoneNumbersResponse listNumbersForPurchase(String countryCode) throws GeneralException, UnauthorizedException, NotFoundException {
+        final String url = String.format("%s/available-phone-numbers", NUMBERS_CALLS_BASE_URL);
         return messageBirdService.requestByID(url, countryCode, PhoneNumbersResponse.class);
     }
 
-    public PhoneNumbersResponse listNumbersForPurchase(String countryCode, PhoneNumbersLookup params) throws IllegalArgumentException, GeneralException, UnauthorizedException, NotFoundException {
-        final String url = String.format("%s/v1/available-phone-numbers", NUMBERS_CALLS_BASE_URL);
+    /**
+     * Lists Numbers that are available to purchase in a particular country code, according to specified search criteria.
+     *
+     * @param countryCode   The country code in which the Number should be purchased.
+     * @param params        Parameters to filter the resulting phone numbers returned.
+     * @throws GeneralException             general exception
+     * @throws UnauthorizedException        if client is unauthorized
+     * @throws NotFoundException            if the resource is missing
+     */
+    public PhoneNumbersResponse listNumbersForPurchase(String countryCode, PhoneNumbersLookup params) throws GeneralException, UnauthorizedException, NotFoundException {
+        final String url = String.format("%s/available-phone-numbers", NUMBERS_CALLS_BASE_URL);
         return messageBirdService.requestByID(url, countryCode, params.toHashMap(), PhoneNumbersResponse.class);
     }
 
+    /**
+     * Purchases a phone number. To be used in conjunction with listNumbersForPurchase to identify available numbers.
+     *
+     * @param number        The number to purchase.
+     * @param countryCode   The country code in which the Number should be purchased.
+     * @throws GeneralException             general exception
+     * @throws UnauthorizedException        if client is unauthorized
+     */
     public PurchasedNumberCreatedResponse purchaseNumber(String number, String countryCode, int billingIntervalMonths) throws UnauthorizedException, GeneralException {
-        final String url = String.format("%s/v1/phone-numbers", NUMBERS_CALLS_BASE_URL);
+        final String url = String.format("%s/phone-numbers", NUMBERS_CALLS_BASE_URL);
 
         final Map<String, Object> payload = new LinkedHashMap<String, Object>();
         payload.put("number", number);
@@ -1591,25 +1642,57 @@ public class MessageBirdClient {
         return messageBirdService.sendPayLoad(url, payload, PurchasedNumberCreatedResponse.class);
     }
 
+    /**
+     * Lists Numbers that were purchased using the account credentials that the client was initialized with.
+     *
+     * @param filter Filters the list of purchased numbers according to search criteria.
+     * @throws UnauthorizedException        if client is unauthorized
+     * @throws GeneralException             general exception
+     * @throws NotFoundException            if the resource is missing
+     */
     public PurchasedNumbersResponse listPurchasedNumbers(PurchasedNumbersFilter filter) throws UnauthorizedException, GeneralException, NotFoundException {
-        final String url = String.format("%s/v1/phone-numbers", NUMBERS_CALLS_BASE_URL);
+        final String url = String.format("%s/phone-numbers", NUMBERS_CALLS_BASE_URL);
         return messageBirdService.requestByID(url, null, filter.toHashMap(), PurchasedNumbersResponse.class);
     }
 
+    /**
+     * Returns a Number that has already been purchased on the initialized account.
+     *
+     * @param number The number whose data should be returned.
+     * @throws UnauthorizedException        if client is unauthorized
+     * @throws GeneralException             general exception
+     * @throws NotFoundException            if the Number is missing
+     */
     public PurchasedNumber viewPurchasedNumber(String number) throws UnauthorizedException, GeneralException, NotFoundException {
-        final String url = String.format("%s/v1/phone-numbers", NUMBERS_CALLS_BASE_URL);
+        final String url = String.format("%s/phone-numbers", NUMBERS_CALLS_BASE_URL);
         return messageBirdService.requestByID(url, number, PurchasedNumber.class);
     }
 
+    /**
+     * Updates tags on a particular existing Number. Any number of parameters after the number can be given to apply multiple tags.
+     *
+     * @param number    The number to update.
+     * @param tags      A tag to apply to the number.
+     * @throws UnauthorizedException        if client is unauthorized
+     * @throws GeneralException             general exception
+     */
     public PurchasedNumber updateNumber(String number, String... tags) throws UnauthorizedException, GeneralException {
-        final String url = String.format("%s/v1/phone-numbers/%s", NUMBERS_CALLS_BASE_URL, number);
+        final String url = String.format("%s/phone-numbers/%s", NUMBERS_CALLS_BASE_URL, number);
         final Map<String, List<String>> payload = new HashMap<String, List<String>>();
         payload.put("tags", Arrays.asList(tags));
         return messageBirdService.sendPayLoad("PATCH", url, payload, PurchasedNumber.class);
     }
 
+    /**
+     * Cancels a particular number.
+     *
+     * @param nummber The number to cancel.
+     * @throws GeneralException             general exception
+     * @throws UnauthorizedException        if client is unauthorized
+     * @throws NotFoundException            if the resource is missing
+     */
     public void cancelNumber(String number) throws UnauthorizedException, GeneralException, NotFoundException {
-        final String url = String.format("%s/v1/phone-numbers", NUMBERS_CALLS_BASE_URL);
+        final String url = String.format("%s/phone-numbers", NUMBERS_CALLS_BASE_URL);
         messageBirdService.deleteByID(url, number);
     }
 } 

--- a/api/src/main/java/com/messagebird/MessageBirdClient.java
+++ b/api/src/main/java/com/messagebird/MessageBirdClient.java
@@ -34,6 +34,7 @@ import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.net.URLEncoder;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -1598,5 +1599,12 @@ public class MessageBirdClient {
     public PurchasedNumber viewPurchasedNumber(String number) throws UnauthorizedException, GeneralException, NotFoundException {
         final String url = String.format("%s/v1/phone-numbers", NUMBERS_CALLS_BASE_URL);
         return messageBirdService.requestByID(url, number, PurchasedNumber.class);
+    }
+
+    public PurchasedNumbersResponse updateNumber(String number, String... tags) throws UnauthorizedException, GeneralException {
+        final String url = String.format("%s/v1/phone-numbers/%s", NUMBERS_CALLS_BASE_URL, number);
+        final Map<String, List<String>> payload = new HashMap<String, List<String>>();
+        payload.put("tags", Arrays.asList(tags));
+        return messageBirdService.sendPayLoad("PATCH", url, payload, PurchasedNumbersResponse.class);
     }
 } 

--- a/api/src/main/java/com/messagebird/MessageBirdClient.java
+++ b/api/src/main/java/com/messagebird/MessageBirdClient.java
@@ -19,6 +19,9 @@ import com.messagebird.objects.MessageList;
 import com.messagebird.objects.MessageResponse;
 import com.messagebird.objects.MsgType;
 import com.messagebird.objects.PagedPaging;
+import com.messagebird.objects.PhoneNumber;
+import com.messagebird.objects.PhoneNumberFeature;
+import com.messagebird.objects.PhoneNumbersResponse;
 import com.messagebird.objects.Verify;
 import com.messagebird.objects.VerifyRequest;
 import com.messagebird.objects.VoiceMessage;
@@ -58,6 +61,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.EnumSet;
 
 /**
  * Message bird general client
@@ -87,6 +91,7 @@ public class MessageBirdClient {
     private static final String BASE_URL_CONVERSATIONS_WHATSAPP_SANDBOX = "https://whatsapp-sandbox.messagebird.com/v1";
     
     static final String VOICE_CALLS_BASE_URL = "https://voice.messagebird.com";
+    static final String NUMBERS_CALLS_BASE_URL = "https://numbers.messagebird.com";
     private static String[] supportedLanguages = {"de-DE", "en-AU", "en-UK", "en-US", "es-ES", "es-LA", "fr-FR", "it-IT", "nl-NL", "pt-BR"};
 
     private static final String BALANCEPATH = "/balance";
@@ -1587,4 +1592,21 @@ public class MessageBirdClient {
             throw new IllegalArgumentException("Limit must be > 0");
         }
     }
-}
+
+    public PhoneNumbersResponse listNumbersForPurchase(String countryCode) throws IllegalArgumentException, GeneralException, UnauthorizedException, NotFoundException {
+        if (countryCode == null) {
+            throw new IllegalArgumentException("Country Code must be specified.");
+        }
+        final String url = String.format("%s/v1/available-phone-numbers", NUMBERS_CALLS_BASE_URL);
+        return messageBirdService.requestByID(url, countryCode, PhoneNumbersResponse.class);
+    }
+
+    public PhoneNumbersResponse listNumbersForPurchase(String countryCode, LinkedHashMap<String, Object> params) throws IllegalArgumentException, GeneralException, UnauthorizedException, NotFoundException {
+        if (countryCode == null) {
+            throw new IllegalArgumentException("Country Code must be specified.");
+        }
+        final String url = String.format("%s/v1/available-phone-numbers", NUMBERS_CALLS_BASE_URL);
+        return messageBirdService.requestByID(url, countryCode, params, PhoneNumbersResponse.class);
+    }
+
+} 

--- a/api/src/main/java/com/messagebird/MessageBirdClient.java
+++ b/api/src/main/java/com/messagebird/MessageBirdClient.java
@@ -3,30 +3,7 @@ package com.messagebird;
 import com.messagebird.exceptions.GeneralException;
 import com.messagebird.exceptions.NotFoundException;
 import com.messagebird.exceptions.UnauthorizedException;
-import com.messagebird.objects.Balance;
-import com.messagebird.objects.Contact;
-import com.messagebird.objects.ContactList;
-import com.messagebird.objects.ContactRequest;
-import com.messagebird.objects.ErrorReport;
-import com.messagebird.objects.Group;
-import com.messagebird.objects.GroupList;
-import com.messagebird.objects.GroupRequest;
-import com.messagebird.objects.Hlr;
-import com.messagebird.objects.Lookup;
-import com.messagebird.objects.LookupHlr;
-import com.messagebird.objects.Message;
-import com.messagebird.objects.MessageList;
-import com.messagebird.objects.MessageResponse;
-import com.messagebird.objects.MsgType;
-import com.messagebird.objects.PagedPaging;
-import com.messagebird.objects.PhoneNumbersLookup;
-import com.messagebird.objects.PhoneNumbersResponse;
-import com.messagebird.objects.PurchasedPhoneNumber;
-import com.messagebird.objects.Verify;
-import com.messagebird.objects.VerifyRequest;
-import com.messagebird.objects.VoiceMessage;
-import com.messagebird.objects.VoiceMessageList;
-import com.messagebird.objects.VoiceMessageResponse;
+import com.messagebird.objects.*;
 import com.messagebird.objects.conversations.Conversation;
 import com.messagebird.objects.conversations.ConversationList;
 import com.messagebird.objects.conversations.ConversationMessage;
@@ -1602,7 +1579,7 @@ public class MessageBirdClient {
         return messageBirdService.requestByID(url, countryCode, params.toHashMap(), PhoneNumbersResponse.class);
     }
 
-    public PurchasedPhoneNumber purchaseNumber(String number, String countryCode, int billingIntervalMonths) throws UnauthorizedException, GeneralException {
+    public PurchasedNumberCreatedResponse purchaseNumber(String number, String countryCode, int billingIntervalMonths) throws UnauthorizedException, GeneralException {
         final String url = String.format("%s/v1/phone-numbers", NUMBERS_CALLS_BASE_URL);
 
         final Map<String, Object> payload = new LinkedHashMap<String, Object>();
@@ -1610,6 +1587,16 @@ public class MessageBirdClient {
         payload.put("countryCode", countryCode);
         payload.put("billingIntervalMonths", billingIntervalMonths);
 
-        return messageBirdService.sendPayLoad(url, payload, PurchasedPhoneNumber.class);
+        return messageBirdService.sendPayLoad(url, payload, PurchasedNumberCreatedResponse.class);
+    }
+
+    public PurchasedNumbersResponse listPurchasedNumbers(PurchasedNumbersFilter filter) throws UnauthorizedException, GeneralException, NotFoundException {
+        final String url = String.format("%s/v1/phone-numbers", NUMBERS_CALLS_BASE_URL);
+        return messageBirdService.requestByID(url, null, filter.toHashMap(), PurchasedNumbersResponse.class);
+    }
+
+    public PurchasedNumber viewPurchasedNumber(String number) throws UnauthorizedException, GeneralException, NotFoundException {
+        final String url = String.format("%s/v1/phone-numbers", NUMBERS_CALLS_BASE_URL);
+        return messageBirdService.requestByID(url, number, PurchasedNumber.class);
     }
 } 

--- a/api/src/main/java/com/messagebird/MessageBirdClient.java
+++ b/api/src/main/java/com/messagebird/MessageBirdClient.java
@@ -19,8 +19,7 @@ import com.messagebird.objects.MessageList;
 import com.messagebird.objects.MessageResponse;
 import com.messagebird.objects.MsgType;
 import com.messagebird.objects.PagedPaging;
-import com.messagebird.objects.PhoneNumber;
-import com.messagebird.objects.PhoneNumberFeature;
+import com.messagebird.objects.PhoneNumbersLookup;
 import com.messagebird.objects.PhoneNumbersResponse;
 import com.messagebird.objects.PurchasedPhoneNumber;
 import com.messagebird.objects.Verify;
@@ -62,7 +61,6 @@ import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.EnumSet;
 
 /**
  * Message bird general client
@@ -1595,19 +1593,13 @@ public class MessageBirdClient {
     }
 
     public PhoneNumbersResponse listNumbersForPurchase(String countryCode) throws IllegalArgumentException, GeneralException, UnauthorizedException, NotFoundException {
-        if (countryCode == null) {
-            throw new IllegalArgumentException("Country Code must be specified.");
-        }
         final String url = String.format("%s/v1/available-phone-numbers", NUMBERS_CALLS_BASE_URL);
         return messageBirdService.requestByID(url, countryCode, PhoneNumbersResponse.class);
     }
 
-    public PhoneNumbersResponse listNumbersForPurchase(String countryCode, LinkedHashMap<String, Object> params) throws IllegalArgumentException, GeneralException, UnauthorizedException, NotFoundException {
-        if (countryCode == null) {
-            throw new IllegalArgumentException("Country Code must be specified.");
-        }
+    public PhoneNumbersResponse listNumbersForPurchase(String countryCode, PhoneNumbersLookup params) throws IllegalArgumentException, GeneralException, UnauthorizedException, NotFoundException {
         final String url = String.format("%s/v1/available-phone-numbers", NUMBERS_CALLS_BASE_URL);
-        return messageBirdService.requestByID(url, countryCode, params, PhoneNumbersResponse.class);
+        return messageBirdService.requestByID(url, countryCode, params.toHashMap(), PhoneNumbersResponse.class);
     }
 
     public PurchasedPhoneNumber purchaseNumber(String number, String countryCode, int billingIntervalMonths) throws UnauthorizedException, GeneralException {

--- a/api/src/main/java/com/messagebird/MessageBirdClient.java
+++ b/api/src/main/java/com/messagebird/MessageBirdClient.java
@@ -1601,11 +1601,11 @@ public class MessageBirdClient {
         return messageBirdService.requestByID(url, number, PurchasedNumber.class);
     }
 
-    public PurchasedNumbersResponse updateNumber(String number, String... tags) throws UnauthorizedException, GeneralException {
+    public PurchasedNumber updateNumber(String number, String... tags) throws UnauthorizedException, GeneralException {
         final String url = String.format("%s/v1/phone-numbers/%s", NUMBERS_CALLS_BASE_URL, number);
         final Map<String, List<String>> payload = new HashMap<String, List<String>>();
         payload.put("tags", Arrays.asList(tags));
-        return messageBirdService.sendPayLoad("PATCH", url, payload, PurchasedNumbersResponse.class);
+        return messageBirdService.sendPayLoad("PATCH", url, payload, PurchasedNumber.class);
     }
 
     public void cancelNumber(String number) throws UnauthorizedException, GeneralException, NotFoundException {

--- a/api/src/main/java/com/messagebird/MessageBirdServiceImpl.java
+++ b/api/src/main/java/com/messagebird/MessageBirdServiceImpl.java
@@ -620,8 +620,8 @@ public class MessageBirdServiceImpl implements MessageBirdService {
     /**
      * Encodes a key/value pair with percent encoding.
      *
-     * @param String key
-     * @param Object value
+     * @param key the key name to be used
+     * @param value the value to be assigned to that key
      * @return String
      */
     private String encodeKeyValuePair(String key, Object value) throws UnsupportedEncodingException {

--- a/api/src/main/java/com/messagebird/MessageBirdServiceImpl.java
+++ b/api/src/main/java/com/messagebird/MessageBirdServiceImpl.java
@@ -200,7 +200,6 @@ public class MessageBirdServiceImpl implements MessageBirdService {
         if (!isURLAbsolute(url)) {
             url = serviceUrl + url;
         }
-
         final APIResponse apiResponse = doRequest(requestType, url, payload);
 
         final String body = apiResponse.getBody();
@@ -619,6 +618,17 @@ public class MessageBirdServiceImpl implements MessageBirdService {
     }
 
     /**
+     * Encodes a key/value pair with percent encoding.
+     *
+     * @param String key
+     * @param Object value
+     * @return String
+     */
+    private String encodeKeyValuePair(String key, Object value) throws UnsupportedEncodingException {
+        return URLEncoder.encode(key, String.valueOf(StandardCharsets.UTF_8)) + "=" + URLEncoder.encode(String.valueOf(value), String.valueOf(StandardCharsets.UTF_8));
+    }
+
+    /**
      * Build a path variable for GET requests
      *
      * @param map map for getting path variables
@@ -631,7 +641,30 @@ public class MessageBirdServiceImpl implements MessageBirdService {
                 bpath.append("&");
             }
             try {
-                bpath.append(URLEncoder.encode(param.getKey(), String.valueOf(StandardCharsets.UTF_8))).append("=").append(URLEncoder.encode(String.valueOf(param.getValue()), String.valueOf(StandardCharsets.UTF_8)));
+                // Check to see if the value is a Collection
+                if (param.getValue() instanceof Collection) {
+                    // If it is, cast the value as a Collection explicitly
+                    // so it can be iterated over. Its values should be
+                    // appended to the querystring parameters using the
+                    // original key provided (e.g., ?features=sms&features=mms)
+                    Collection<?> col =  (Collection<?>) param.getValue();
+                    Iterator<?> iterator = col.iterator();
+                    int count = 0;
+                    // While there are still remaining iterables
+                    while (iterator.hasNext()) {
+                        // Append & if not the first iterable
+                        if (count > 0) {
+                            bpath.append("&");
+                        }
+                        // Append the encoded querystring key/value pair.
+                        // the value is returned from the next() call
+                        bpath.append(encodeKeyValuePair(param.getKey(), iterator.next()));
+                        count++;
+                    }   
+                } else {
+                    // If the value is not a collection, create the querystring value directly.
+                    bpath.append(encodeKeyValuePair(param.getKey(), param.getValue()));
+                }
             } catch (UnsupportedEncodingException exception) {
                 // Do nothing
             }

--- a/api/src/main/java/com/messagebird/MessageBirdServiceImpl.java
+++ b/api/src/main/java/com/messagebird/MessageBirdServiceImpl.java
@@ -365,13 +365,13 @@ public class MessageBirdServiceImpl implements MessageBirdService {
             Field modifiersField = Field.class.getDeclaredField("modifiers");
             modifiersField.setAccessible(true);
             modifiersField.setInt(methodsField, methodsField.getModifiers() & ~Modifier.FINAL);
-
+            
             Object noInstanceBecauseStaticField = null;
-
+            
             // Determine what methods should be allowed.
             String[] existingMethods = (String[]) methodsField.get(noInstanceBecauseStaticField);
             String[] allowedMethods = getAllowedMethods(existingMethods);
-
+            
             // Override the actual field to allow PATCH.
             methodsField.set(noInstanceBecauseStaticField, allowedMethods);
 

--- a/api/src/main/java/com/messagebird/objects/MsgType.java
+++ b/api/src/main/java/com/messagebird/objects/MsgType.java
@@ -7,6 +7,7 @@ package com.messagebird.objects;
  */
 public enum MsgType {
     sms("sms"),
+    mms("mms"),
     binary("binary"),
     premium("premium"),
     flash("flash");

--- a/api/src/main/java/com/messagebird/objects/PhoneNumber.java
+++ b/api/src/main/java/com/messagebird/objects/PhoneNumber.java
@@ -1,0 +1,50 @@
+package com.messagebird.objects;
+
+import com.messagebird.objects.PhoneNumberFeature;
+
+import java.util.EnumSet;
+
+public class PhoneNumber {
+    private String number;
+    private String country;
+    private String region;
+    private String locality;
+    private EnumSet<PhoneNumberFeature> features;
+    private String type;
+
+    public String getNumber() {
+        return this.number;
+    }
+
+    public String getCountry() {
+        return this.country;
+    }
+
+    public String getRegion() {
+        return this.region;
+    }
+
+    public String getLocality() {
+        return this.locality;
+    }
+
+    public EnumSet<PhoneNumberFeature> getFeatures() {
+        return this.features;
+    }
+
+    public String getType() {
+        return this.type;
+    }
+
+    @Override
+    public String toString() {
+        return "PhoneNumber{" +
+            "number='" + number + "\'" +
+            ", country='" + country + "\'" +
+            ", region='" + region + "\'" +
+            ", locality='" + locality + "\'" +
+            ", features=" + features +
+            ", type='" + type + "\'" +
+            "}";
+    }
+}

--- a/api/src/main/java/com/messagebird/objects/PhoneNumber.java
+++ b/api/src/main/java/com/messagebird/objects/PhoneNumber.java
@@ -3,7 +3,6 @@ package com.messagebird.objects;
 import com.messagebird.objects.PhoneNumberFeature;
 
 import java.util.EnumSet;
-import java.util.List;
 
 public class PhoneNumber {
     private String number;

--- a/api/src/main/java/com/messagebird/objects/PhoneNumber.java
+++ b/api/src/main/java/com/messagebird/objects/PhoneNumber.java
@@ -3,6 +3,7 @@ package com.messagebird.objects;
 import com.messagebird.objects.PhoneNumberFeature;
 
 import java.util.EnumSet;
+import java.util.List;
 
 public class PhoneNumber {
     private String number;

--- a/api/src/main/java/com/messagebird/objects/PhoneNumberFeature.java
+++ b/api/src/main/java/com/messagebird/objects/PhoneNumberFeature.java
@@ -1,0 +1,19 @@
+package com.messagebird.objects;
+
+public enum PhoneNumberFeature {
+    
+    SMS("sms"),
+    MMS("mms"),
+    VOICE("voice");
+
+    private String type;
+
+    PhoneNumberFeature(String type) {
+        this.type = type;
+    }
+
+    @Override
+    public String toString() {
+        return this.type;
+    }
+}

--- a/api/src/main/java/com/messagebird/objects/PhoneNumberSearchPattern.java
+++ b/api/src/main/java/com/messagebird/objects/PhoneNumberSearchPattern.java
@@ -1,0 +1,18 @@
+package com.messagebird.objects;
+
+public enum PhoneNumberSearchPattern {
+    START("start"),
+    ANYWHERE("anywhere"),
+    END("end");
+
+    private String type;
+
+    PhoneNumberSearchPattern(String type) {
+        this.type = type;
+    }
+
+    @Override
+    public String toString() {
+        return this.type;
+    }
+}

--- a/api/src/main/java/com/messagebird/objects/PhoneNumberType.java
+++ b/api/src/main/java/com/messagebird/objects/PhoneNumberType.java
@@ -1,0 +1,18 @@
+package com.messagebird.objects;
+
+public enum PhoneNumberType {
+    LANDLINE("landline"),
+    MOBILE("mobile"),
+    PREMIUM_RATE("premium_rate");
+
+    private String type;
+
+    PhoneNumberType(String type) {
+        this.type = type;
+    }
+
+    @Override
+    public String toString() {
+        return this.type;
+    }
+}

--- a/api/src/main/java/com/messagebird/objects/PhoneNumbersLookup.java
+++ b/api/src/main/java/com/messagebird/objects/PhoneNumbersLookup.java
@@ -3,8 +3,9 @@ package com.messagebird.objects;
 import com.messagebird.exceptions.GeneralException;
 import com.messagebird.objects.PhoneNumberFeature;
 import com.messagebird.objects.PhoneNumberType;
-import com.messagebird.objects.PhoneNumberSearchPattern;;
+import com.messagebird.objects.PhoneNumberSearchPattern;
 
+import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.lang.reflect.Field;
@@ -43,6 +44,12 @@ public class PhoneNumbersLookup {
     
     public void setFeatures(EnumSet<PhoneNumberFeature> features) {
         this.features = features;
+    }
+
+    public void setFeatures(PhoneNumberFeature... features) {
+        EnumSet<PhoneNumberFeature> featuresEnum = EnumSet.noneOf(PhoneNumberFeature.class);
+        featuresEnum.addAll(Arrays.asList(features));
+        this.features = featuresEnum;
     }
     
     public void setType(PhoneNumberType type) {

--- a/api/src/main/java/com/messagebird/objects/PhoneNumbersLookup.java
+++ b/api/src/main/java/com/messagebird/objects/PhoneNumbersLookup.java
@@ -1,0 +1,86 @@
+package com.messagebird.objects;
+
+import com.messagebird.exceptions.GeneralException;
+import com.messagebird.objects.PhoneNumberFeature;
+import com.messagebird.objects.PhoneNumberType;
+import com.messagebird.objects.PhoneNumberSearchPattern;;
+
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.lang.reflect.Field;
+
+public class PhoneNumbersLookup {
+
+    private Number number;
+    private Number limit;
+    private EnumSet<PhoneNumberFeature> features;
+    private PhoneNumberType type;
+    private PhoneNumberSearchPattern searchPattern;
+
+    public Number getNumber() {
+        return this.number;
+    }
+
+    public EnumSet<PhoneNumberFeature> getFeatures() {
+        return this.features;
+    }
+
+    public PhoneNumberType getType() {
+        return this.type;
+    }
+
+    public Number getLimit() {
+        return this.limit;
+    }
+
+    public PhoneNumberSearchPattern getSearchPattern() {
+        return this.searchPattern;
+    }
+
+	public void setNumber(Number number) {
+        this.number = number;
+    }
+    
+    public void setFeatures(EnumSet<PhoneNumberFeature> features) {
+        this.features = features;
+    }
+    
+    public void setType(PhoneNumberType type) {
+        this.type = type;
+    }
+    
+    public void setLimit(Number limit) {
+        this.limit = limit;
+    }
+
+    public void setSearchPattern(PhoneNumberSearchPattern searchPattern) {
+        this.searchPattern = searchPattern;
+    }
+
+    public HashMap<String, Object> toHashMap() throws GeneralException {
+        final HashMap<String, Object> map = new HashMap<String, Object>();
+        for (Field f: getClass().getDeclaredFields()) {
+            try {
+                Object value = f.get(this);
+                String key = f.getName();
+                if (value != null) {
+                    map.put(key, value);
+                }
+            } catch (IllegalAccessException exception) {
+                throw new GeneralException("Error Converting PhoneNumbersLookup Class to HashMap.");
+            }
+        }
+        return map;
+    }
+
+    @Override
+    public String toString() {
+        return "PhoneNumbersLookup{" +
+            " number='" + number + "'" +
+            ", features='" + features + "'" +
+            ", type='" + type + "'" +
+            ", limit='" + limit + "'" +
+            ", searchPattern='" + searchPattern + "'" +
+            "}";
+    }    
+}

--- a/api/src/main/java/com/messagebird/objects/PhoneNumbersResponse.java
+++ b/api/src/main/java/com/messagebird/objects/PhoneNumbersResponse.java
@@ -1,0 +1,38 @@
+package com.messagebird.objects;
+
+import com.messagebird.objects.PhoneNumber;
+
+import java.util.List;
+
+import java.io.Serializable;
+
+public class PhoneNumbersResponse implements Serializable {
+    /**
+     *
+     */
+    private static final long serialVersionUID = 6177098534499444839L;
+    private Number limit;
+    private Number offset;
+    private List<PhoneNumber> items;
+
+    public Number getLimit() {
+        return this.limit;
+    }
+
+    public Number getOffset() {
+        return this.offset;
+    }
+
+    public List<PhoneNumber> getItems() {
+        return this.items;
+    }
+    
+    @Override
+    public String toString() {
+        return "PhoneNumbersResponse{" +
+            "limit=" + limit +
+            ", offset=" + offset +
+            ", items=" + items +
+            "}";
+    }
+}

--- a/api/src/main/java/com/messagebird/objects/PurchasedNumber.java
+++ b/api/src/main/java/com/messagebird/objects/PurchasedNumber.java
@@ -3,11 +3,9 @@ package com.messagebird.objects;
 import java.util.Date;
 import java.util.List;
 
-public class PurchasedPhoneNumber extends PhoneNumber {
+public class PurchasedNumber extends PhoneNumber {
     private List<String> tags;
     private String status;
-    private Date createdAt;
-    private Date renewalAt;
 
     public List<String> getTags() {
         return tags;
@@ -15,14 +13,6 @@ public class PurchasedPhoneNumber extends PhoneNumber {
 
     public String getStatus() {
         return status;
-    }
-
-    public Date getCreatedAt() {
-        return createdAt;
-    }
-
-    public Date getRenewalAt() {
-        return renewalAt;
     }
 
     @Override
@@ -36,8 +26,6 @@ public class PurchasedPhoneNumber extends PhoneNumber {
             ", type='" + this.getType() + "\'" +
             ", tags='" + tags + "\'" +
             ", status='" + status + "\'" +
-            ", createdAt='" + createdAt + "\'" +
-            ", renewalAt='" + renewalAt + "\'" +
             "}";
     }
 }

--- a/api/src/main/java/com/messagebird/objects/PurchasedNumber.java
+++ b/api/src/main/java/com/messagebird/objects/PurchasedNumber.java
@@ -1,6 +1,5 @@
 package com.messagebird.objects;
 
-import java.util.Date;
 import java.util.List;
 
 public class PurchasedNumber extends PhoneNumber {

--- a/api/src/main/java/com/messagebird/objects/PurchasedNumberCreatedResponse.java
+++ b/api/src/main/java/com/messagebird/objects/PurchasedNumberCreatedResponse.java
@@ -1,7 +1,6 @@
 package com.messagebird.objects;
 
 import java.util.Date;
-import java.util.EnumSet;
 
 public class PurchasedNumberCreatedResponse extends PurchasedNumber {
     private Date createdAt;

--- a/api/src/main/java/com/messagebird/objects/PurchasedNumberCreatedResponse.java
+++ b/api/src/main/java/com/messagebird/objects/PurchasedNumberCreatedResponse.java
@@ -1,0 +1,33 @@
+package com.messagebird.objects;
+
+import java.util.Date;
+import java.util.List;
+
+public class PurchasedNumberCreatedResponse extends PurchasedNumber {
+    private Date createdAt;
+    private Date renewalAt;
+
+    public Date getCreatedAt() {
+        return createdAt;
+    }
+
+    public Date getRenewalAt() {
+        return renewalAt;
+    }
+
+    @Override
+    public String toString() {
+        return "PhoneNumber{" +
+            "number='" + this.getNumber() + "\'" +
+            ", country='" + this.getCountry() + "\'" +
+            ", region='" + this.getRegion() + "\'" +
+            ", locality='" + this.getLocality() + "\'" +
+            ", features=" + this.getFeatures() +
+            ", type='" + this.getType() + "\'" +
+            ", tags='" + this.getTags() + "\'" +
+            ", status='" + this.getStatus() + "\'" +
+            ", createdAt='" + createdAt + "\'" +
+            ", renewalAt='" + renewalAt + "\'" +
+            "}";
+    }
+}

--- a/api/src/main/java/com/messagebird/objects/PurchasedNumberCreatedResponse.java
+++ b/api/src/main/java/com/messagebird/objects/PurchasedNumberCreatedResponse.java
@@ -1,7 +1,7 @@
 package com.messagebird.objects;
 
 import java.util.Date;
-import java.util.List;
+import java.util.EnumSet;
 
 public class PurchasedNumberCreatedResponse extends PurchasedNumber {
     private Date createdAt;

--- a/api/src/main/java/com/messagebird/objects/PurchasedNumbersFilter.java
+++ b/api/src/main/java/com/messagebird/objects/PurchasedNumbersFilter.java
@@ -5,6 +5,7 @@ import com.messagebird.exceptions.GeneralException;
 import java.io.Serializable;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
 
@@ -39,9 +40,7 @@ public class PurchasedNumbersFilter implements Serializable {
     }
 
     public void addFeature(PhoneNumberFeature... features) {
-        for (PhoneNumberFeature feature: features) {
-            this.features.add(feature);
-        }
+        Collections.addAll(this.features, features);
     }
 
     public void removeFeature(PhoneNumberFeature... features) {

--- a/api/src/main/java/com/messagebird/objects/PurchasedNumbersFilter.java
+++ b/api/src/main/java/com/messagebird/objects/PurchasedNumbersFilter.java
@@ -38,20 +38,34 @@ public class PurchasedNumbersFilter implements Serializable {
         return features;
     }
 
-    public void addFeature(PhoneNumberFeature feature) {
-        this.features.add(feature);
+    public void addFeature(PhoneNumberFeature... features) {
+        for (PhoneNumberFeature feature: features) {
+            this.features.add(feature);
+        }
     }
 
-    public void removeFeature(PhoneNumberFeature feature) {
-        this.features.remove(feature);
+    public void removeFeature(PhoneNumberFeature... features) {
+        for (PhoneNumberFeature feature: features) {
+            this.features.remove(feature);
+        }
     }
 
     public ArrayList<String> getTags() {
         return tags;
     }
 
-    public void addTag(String tag) {
-        this.tags.add(tag);
+    public void addTag(String... tags) {
+        for (String tag: tags) {
+            if (!this.tags.contains(tag)) {
+                this.tags.add(tag);
+            }
+        }
+    }
+
+    public void removeTag(String... tags) {
+        for (String tag: tags) {
+            this.tags.remove(tag);
+        }
     }
 
     public void clearTags() {
@@ -114,11 +128,11 @@ public class PurchasedNumbersFilter implements Serializable {
                 "limit=" + limit +
                 ", offset=" + offset +
                 ", features=" + features +
-                ", tags=" + tags.toString() +
+                ", tags=" + tags +
                 ", number='" + number + '\'' +
                 ", region='" + region + '\'' +
                 ", locality='" + locality + '\'' +
-                ", type='" + type + '\'' +
+                ", type=" + type +
                 '}';
     }
 }

--- a/api/src/main/java/com/messagebird/objects/PurchasedNumbersFilter.java
+++ b/api/src/main/java/com/messagebird/objects/PurchasedNumbersFilter.java
@@ -1,0 +1,124 @@
+package com.messagebird.objects;
+
+import com.messagebird.exceptions.GeneralException;
+
+import java.io.Serializable;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.HashMap;
+
+public class PurchasedNumbersFilter implements Serializable {
+    private int limit = 10;
+    private int offset = 0;
+    private EnumSet<PhoneNumberFeature> features = EnumSet.noneOf(PhoneNumberFeature.class);
+    private ArrayList<String> tags = new ArrayList<>();
+    private String number;
+    private String region;
+    private String locality;
+    private PhoneNumberType type;
+
+    public int getLimit() {
+        return limit;
+    }
+
+    public void setLimit(int limit) {
+        this.limit = limit;
+    }
+
+    public int getOffset() {
+        return offset;
+    }
+
+    public void setOffset(int offset) {
+        this.offset = offset;
+    }
+
+    public EnumSet<PhoneNumberFeature> getFeatures() {
+        return features;
+    }
+
+    public void addFeature(PhoneNumberFeature feature) {
+        this.features.add(feature);
+    }
+
+    public void removeFeature(PhoneNumberFeature feature) {
+        this.features.remove(feature);
+    }
+
+    public ArrayList<String> getTags() {
+        return tags;
+    }
+
+    public void addTag(String tag) {
+        this.tags.add(tag);
+    }
+
+    public void clearTags() {
+        this.tags.clear();
+    }
+
+    public String getNumber() {
+        return number;
+    }
+
+    public void setNumber(String number) {
+        this.number = number;
+    }
+
+    public String getRegion() {
+        return region;
+    }
+
+    public void setRegion(String region) {
+        this.region = region;
+    }
+
+    public String getLocality() {
+        return locality;
+    }
+
+    public void setLocality(String locality) {
+        this.locality = locality;
+    }
+
+    public PhoneNumberType getType() {
+        return type;
+    }
+
+    public void setType(PhoneNumberType type) {
+        this.type = type;
+    }
+
+    public HashMap<String, Object> toHashMap() throws GeneralException {
+        final HashMap<String, Object> map = new HashMap<String, Object>();
+        for (Field f: getClass().getDeclaredFields()) {
+            if (f.canAccess(this)) {
+                try {
+                    Object value = f.get(this);
+                    String key = f.getName();
+                    if (value != null) {
+                        map.put(key, value);
+                    }
+                } catch (IllegalAccessException exception) {
+                    throw new GeneralException("Error converting to HashMap.");
+                }
+            }
+        }
+        return map;
+    }
+
+    @Override
+    public String toString() {
+        return "PurchasedNumbersFilter{" +
+                "limit=" + limit +
+                ", offset=" + offset +
+                ", features=" + features +
+                ", tags=" + tags.toString() +
+                ", number='" + number + '\'' +
+                ", region='" + region + '\'' +
+                ", locality='" + locality + '\'' +
+                ", type='" + type + '\'' +
+                '}';
+    }
+}

--- a/api/src/main/java/com/messagebird/objects/PurchasedNumbersResponse.java
+++ b/api/src/main/java/com/messagebird/objects/PurchasedNumbersResponse.java
@@ -1,0 +1,42 @@
+package com.messagebird.objects;
+
+import java.util.List;
+
+public class PurchasedNumbersResponse {
+    private int offset;
+    private int limit;
+    private int count;
+    private int totalCount;
+    private List<PurchasedNumber> items;
+
+    public int getOffset() {
+        return offset;
+    }
+
+    public int getLimit() {
+        return limit;
+    }
+
+    public int getCount() {
+        return count;
+    }
+
+    public int getTotalCount() {
+        return totalCount;
+    }
+
+    public List<PurchasedNumber> getItems() {
+        return items;
+    }
+
+    @Override
+    public String toString() {
+        return "PurchasedNumbersResponse{" +
+                "offset=" + offset +
+                ", limit=" + limit +
+                ", count=" + count +
+                ", totalCount=" + totalCount +
+                ", items=" + items +
+                '}';
+    }
+}

--- a/api/src/main/java/com/messagebird/objects/PurchasedPhoneNumber.java
+++ b/api/src/main/java/com/messagebird/objects/PurchasedPhoneNumber.java
@@ -1,0 +1,43 @@
+package com.messagebird.objects;
+
+import java.util.Date;
+import java.util.List;
+
+public class PurchasedPhoneNumber extends PhoneNumber {
+    private List<String> tags;
+    private String status;
+    private Date createdAt;
+    private Date renewalAt;
+
+    public List<String> getTags() {
+        return tags;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public Date getCreatedAt() {
+        return createdAt;
+    }
+
+    public Date getRenewalAt() {
+        return renewalAt;
+    }
+
+    @Override
+    public String toString() {
+        return "PhoneNumber{" +
+            "number='" + this.getNumber() + "\'" +
+            ", country='" + this.getCountry() + "\'" +
+            ", region='" + this.getRegion() + "\'" +
+            ", locality='" + this.getLocality() + "\'" +
+            ", features=" + this.getFeatures() +
+            ", type='" + this.getType() + "\'" +
+            ", tags='" + tags + "\'" +
+            ", status='" + status + "\'" +
+            ", createdAt='" + createdAt + "\'" +
+            ", renewalAt='" + renewalAt + "\'" +
+            "}";
+    }
+}

--- a/api/src/test/java/com/messagebird/MessageBirdClientTest.java
+++ b/api/src/test/java/com/messagebird/MessageBirdClientTest.java
@@ -775,7 +775,7 @@ public class MessageBirdClientTest {
 
     @Test
     public void testListNumbersForPurchase() throws IllegalArgumentException, GeneralException, UnauthorizedException, NotFoundException {
-        final String url = String.format("%s/v1/available-phone-numbers", NUMBERS_CALLS_BASE_URL);
+        final String url = String.format("%s/available-phone-numbers", NUMBERS_CALLS_BASE_URL);
         final PhoneNumbersResponse mockedResponse = new PhoneNumbersResponse();
 
         MessageBirdService messageBirdServiceMock = mock(MessageBirdService.class);
@@ -793,7 +793,7 @@ public class MessageBirdClientTest {
 
     @Test
     public void testListNumbersForPurchaseWithParams() throws IllegalArgumentException, GeneralException, UnauthorizedException, NotFoundException {
-        final String url = String.format("%s/v1/available-phone-numbers", NUMBERS_CALLS_BASE_URL);
+        final String url = String.format("%s/available-phone-numbers", NUMBERS_CALLS_BASE_URL);
         final PhoneNumbersResponse mockedResponse = new PhoneNumbersResponse();
 
         MessageBirdService messageBirdServiceMock = mock(MessageBirdService.class);
@@ -817,7 +817,7 @@ public class MessageBirdClientTest {
 
     @Test
     public void testPurchaseNumber() throws UnauthorizedException, GeneralException {
-        final String url = String.format("%s/v1/phone-numbers", NUMBERS_CALLS_BASE_URL);
+        final String url = String.format("%s/phone-numbers", NUMBERS_CALLS_BASE_URL);
 
         PurchasedNumberCreatedResponse purchasedNumberMockData = new PurchasedNumberCreatedResponse();
 
@@ -839,7 +839,7 @@ public class MessageBirdClientTest {
     
     @Test
     public void testListPurchasedNumbers() throws UnauthorizedException, GeneralException, NotFoundException {
-        final String url = String.format("%s/v1/phone-numbers", NUMBERS_CALLS_BASE_URL);
+        final String url = String.format("%s/phone-numbers", NUMBERS_CALLS_BASE_URL);
     
         PurchasedNumbersResponse purchasedNumbersMockData = new PurchasedNumbersResponse();
     
@@ -864,7 +864,7 @@ public class MessageBirdClientTest {
 
     @Test
     public void testViewPurchasedNumber()  throws UnauthorizedException, GeneralException, NotFoundException {
-        final String url = String.format("%s/v1/phone-numbers", NUMBERS_CALLS_BASE_URL);
+        final String url = String.format("%s/phone-numbers", NUMBERS_CALLS_BASE_URL);
     
         PurchasedNumber purchasedNumberMockData = new PurchasedNumber();
     
@@ -882,7 +882,7 @@ public class MessageBirdClientTest {
     @Test
     public void updatePurchasedNumber()  throws UnauthorizedException, GeneralException, NotFoundException {
         final String phoneNumber = "15625267429";
-        final String url = String.format("%s/v1/phone-numbers/%s", NUMBERS_CALLS_BASE_URL, phoneNumber);
+        final String url = String.format("%s/phone-numbers/%s", NUMBERS_CALLS_BASE_URL, phoneNumber);
     
         PurchasedNumber updatedNumberMock = new PurchasedNumber();
     
@@ -890,7 +890,7 @@ public class MessageBirdClientTest {
         MessageBirdClient messageBirdClientMock = new MessageBirdClient(messageBirdServiceMock);
         
         final Map<String, List<String>> payload = new HashMap<String, List<String>>();
-        payload.put("tags", Arrays.asList("tag"));
+        payload.put("tags", Collections.singletonList("tag"));
         
         when(messageBirdServiceMock.sendPayLoad("PATCH", url, payload, PurchasedNumber.class))
             .thenReturn(updatedNumberMock);
@@ -903,7 +903,7 @@ public class MessageBirdClientTest {
     @Test
     public void deletePurchasedNumber()  throws UnauthorizedException, GeneralException, NotFoundException {
         final String phoneNumber = "15625267429";
-        final String url = String.format("%s/v1/phone-numbers", NUMBERS_CALLS_BASE_URL);
+        final String url = String.format("%s/phone-numbers", NUMBERS_CALLS_BASE_URL);
     
         MessageBirdService messageBirdServiceMock = mock(MessageBirdService.class);
         MessageBirdClient messageBirdClientMock = new MessageBirdClient(messageBirdServiceMock);

--- a/api/src/test/java/com/messagebird/MessageBirdClientTest.java
+++ b/api/src/test/java/com/messagebird/MessageBirdClientTest.java
@@ -880,7 +880,7 @@ public class MessageBirdClientTest {
     }
 
     @Test
-    public void updatePurchasedNumber()  throws UnauthorizedException, GeneralException, NotFoundException {
+    public void updatePurchasedNumber()  throws UnauthorizedException, GeneralException {
         final String phoneNumber = "15625267429";
         final String url = String.format("%s/phone-numbers/%s", NUMBERS_CALLS_BASE_URL, phoneNumber);
     

--- a/api/src/test/java/com/messagebird/MessageBirdClientTest.java
+++ b/api/src/test/java/com/messagebird/MessageBirdClientTest.java
@@ -12,8 +12,11 @@ import org.mockito.Mockito;
 
 import java.io.UnsupportedEncodingException;
 import java.math.BigInteger;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 import static com.messagebird.MessageBirdClient.*;
@@ -769,4 +772,144 @@ public class MessageBirdClientTest {
         messageBirdClientMock.deleteWebhook("id");
         verify(messageBirdServiceMock, times(1)).deleteByID(VOICE_CALLS_BASE_URL + WEBHOOKS, "id");
     }
+
+    @Test
+    public void testListNumbersForPurchase() throws IllegalArgumentException, GeneralException, UnauthorizedException, NotFoundException {
+        final String url = String.format("%s/v1/available-phone-numbers", NUMBERS_CALLS_BASE_URL);
+        final PhoneNumbersResponse mockedResponse = new PhoneNumbersResponse();
+
+        MessageBirdService messageBirdServiceMock = mock(MessageBirdService.class);
+        MessageBirdClient messageBirdClientMock = new MessageBirdClient(messageBirdServiceMock);
+
+        when(messageBirdServiceMock.requestByID(url, "NL", PhoneNumbersResponse.class))
+            .thenReturn(mockedResponse);
+
+        final PhoneNumbersResponse response = messageBirdClientMock.listNumbersForPurchase("NL");
+        verify(messageBirdServiceMock, times(1)).requestByID(url, "NL", PhoneNumbersResponse.class);
+        
+        assertNotNull(response);
+        assertEquals(response, mockedResponse);
+    }
+
+    @Test
+    public void testListNumbersForPurchaseWithParams() throws IllegalArgumentException, GeneralException, UnauthorizedException, NotFoundException {
+        final String url = String.format("%s/v1/available-phone-numbers", NUMBERS_CALLS_BASE_URL);
+        final PhoneNumbersResponse mockedResponse = new PhoneNumbersResponse();
+
+        MessageBirdService messageBirdServiceMock = mock(MessageBirdService.class);
+        MessageBirdClient messageBirdClientMock = new MessageBirdClient(messageBirdServiceMock);
+
+        PhoneNumbersLookup options = new PhoneNumbersLookup();
+        options.setFeatures(PhoneNumberFeature.VOICE, PhoneNumberFeature.SMS);
+        options.setType(PhoneNumberType.MOBILE);
+        options.setLimit(1);
+        options.setNumber(562);
+        options.setSearchPattern(PhoneNumberSearchPattern.START);
+    
+        when(messageBirdServiceMock.requestByID(url, "US", options.toHashMap(), PhoneNumbersResponse.class))
+            .thenReturn(mockedResponse);
+
+        final PhoneNumbersResponse response = messageBirdClientMock.listNumbersForPurchase("US", options);
+        verify(messageBirdServiceMock, times(1)).requestByID(url, "US", options.toHashMap(), PhoneNumbersResponse.class);
+        assertNotNull(response);
+        assertEquals(response, mockedResponse);
+    }
+
+    @Test
+    public void testPurchaseNumber() throws UnauthorizedException, GeneralException {
+        final String url = String.format("%s/v1/phone-numbers", NUMBERS_CALLS_BASE_URL);
+
+        PurchasedNumberCreatedResponse purchasedNumberMockData = new PurchasedNumberCreatedResponse();
+
+        MessageBirdService messageBirdServiceMock = mock(MessageBirdService.class);
+        MessageBirdClient messageBirdClientMock = new MessageBirdClient(messageBirdServiceMock);
+        
+        final Map<String, Object> payload = new LinkedHashMap<String, Object>();
+        payload.put("number", "15625267429");
+        payload.put("countryCode", "US");
+        payload.put("billingIntervalMonths", 1);
+        
+        when(messageBirdServiceMock.sendPayLoad(url, payload, PurchasedNumberCreatedResponse.class))
+            .thenReturn(purchasedNumberMockData);
+        final PurchasedNumberCreatedResponse response = messageBirdClientMock.purchaseNumber("15625267429", "US", 1);
+        verify(messageBirdServiceMock, times(1)).sendPayLoad(url, payload, PurchasedNumberCreatedResponse.class);
+        assertNotNull(response);
+        assertEquals(response, purchasedNumberMockData);
+    }
+    
+    @Test
+    public void testListPurchasedNumbers() throws UnauthorizedException, GeneralException, NotFoundException {
+        final String url = String.format("%s/v1/phone-numbers", NUMBERS_CALLS_BASE_URL);
+    
+        PurchasedNumbersResponse purchasedNumbersMockData = new PurchasedNumbersResponse();
+    
+        MessageBirdService messageBirdServiceMock = mock(MessageBirdService.class);
+        MessageBirdClient messageBirdClientMock = new MessageBirdClient(messageBirdServiceMock);
+
+        PurchasedNumbersFilter filter = new PurchasedNumbersFilter();
+        filter.setLimit(1);
+        filter.addFeature(PhoneNumberFeature.SMS);
+        filter.setType(PhoneNumberType.MOBILE);
+        filter.addTag("tag");
+
+        when(messageBirdServiceMock.requestByID(url, null, filter.toHashMap(), PurchasedNumbersResponse.class))
+            .thenReturn(purchasedNumbersMockData);
+
+        final PurchasedNumbersResponse response = messageBirdClientMock.listPurchasedNumbers(filter);
+
+        verify(messageBirdServiceMock, times(1)).requestByID(url, null, filter.toHashMap(), PurchasedNumbersResponse.class);
+        assertNotNull(response);
+        assertEquals(response, purchasedNumbersMockData);
+    }
+
+    @Test
+    public void testViewPurchasedNumber()  throws UnauthorizedException, GeneralException, NotFoundException {
+        final String url = String.format("%s/v1/phone-numbers", NUMBERS_CALLS_BASE_URL);
+    
+        PurchasedNumber purchasedNumberMockData = new PurchasedNumber();
+    
+        MessageBirdService messageBirdServiceMock = mock(MessageBirdService.class);
+        MessageBirdClient messageBirdClientMock = new MessageBirdClient(messageBirdServiceMock);
+        when(messageBirdServiceMock.requestByID(url, "15625267429", PurchasedNumber.class))
+            .thenReturn(purchasedNumberMockData);
+        final PurchasedNumber response = messageBirdClientMock.viewPurchasedNumber("15625267429");
+
+        verify(messageBirdServiceMock, times(1)).requestByID(url, "15625267429", PurchasedNumber.class);
+        assertNotNull(response);
+        assertEquals(response, purchasedNumberMockData);
+    }
+
+    @Test
+    public void updatePurchasedNumber()  throws UnauthorizedException, GeneralException, NotFoundException {
+        final String phoneNumber = "15625267429";
+        final String url = String.format("%s/v1/phone-numbers/%s", NUMBERS_CALLS_BASE_URL, phoneNumber);
+    
+        PurchasedNumber updatedNumberMock = new PurchasedNumber();
+    
+        MessageBirdService messageBirdServiceMock = mock(MessageBirdService.class);
+        MessageBirdClient messageBirdClientMock = new MessageBirdClient(messageBirdServiceMock);
+        
+        final Map<String, List<String>> payload = new HashMap<String, List<String>>();
+        payload.put("tags", Arrays.asList("tag"));
+        
+        when(messageBirdServiceMock.sendPayLoad("PATCH", url, payload, PurchasedNumber.class))
+            .thenReturn(updatedNumberMock);
+        final PurchasedNumber response = messageBirdClientMock.updateNumber(phoneNumber, "tag");
+        verify(messageBirdServiceMock, times(1)).sendPayLoad("PATCH", url, payload, PurchasedNumber.class);
+        assertNotNull(response);
+        assertEquals(response, updatedNumberMock);
+    }
+
+    @Test
+    public void deletePurchasedNumber()  throws UnauthorizedException, GeneralException, NotFoundException {
+        final String phoneNumber = "15625267429";
+        final String url = String.format("%s/v1/phone-numbers", NUMBERS_CALLS_BASE_URL);
+    
+        MessageBirdService messageBirdServiceMock = mock(MessageBirdService.class);
+        MessageBirdClient messageBirdClientMock = new MessageBirdClient(messageBirdServiceMock);
+        
+        messageBirdClientMock.cancelNumber(phoneNumber);
+        verify(messageBirdServiceMock, times(1)).deleteByID(url, phoneNumber);
+    }
+
 }

--- a/api/src/test/java/com/messagebird/PurchasedNumbersFilterTest.java
+++ b/api/src/test/java/com/messagebird/PurchasedNumbersFilterTest.java
@@ -1,0 +1,213 @@
+package com.messagebird;
+
+import com.messagebird.exceptions.GeneralException;
+import com.messagebird.exceptions.UnauthorizedException;
+import com.messagebird.objects.*;
+import org.junit.Test;
+
+import java.lang.reflect.Array;
+import java.util.*;
+
+import static org.junit.Assert.*;
+import static org.junit.Assert.assertNull;
+
+public class PurchasedNumbersFilterTest {
+
+    @Test
+    public void testDefaults() {
+        // Setup
+        PurchasedNumbersFilter filter = new PurchasedNumbersFilter();
+
+        // Test
+        assertEquals(10, filter.getLimit());
+        assertEquals(0, filter.getOffset());
+        assertEquals(0, filter.getFeatures().size());
+        assertEquals(0, filter.getTags().size());
+        assertNull(filter.getNumber());
+        assertNull(filter.getRegion());
+        assertNull(filter.getLocality());
+        assertNull(filter.getType());
+    }
+
+    @Test
+    public void testAddingFeatures() {
+        // Setup
+        PurchasedNumbersFilter filter = new PurchasedNumbersFilter();
+
+        assertEquals(EnumSet.noneOf(PhoneNumberFeature.class), filter.getFeatures());
+
+        // Test can add a feature
+        filter.addFeature(PhoneNumberFeature.SMS);
+        assertEquals(EnumSet.of(PhoneNumberFeature.SMS), filter.getFeatures());
+
+        // Test can have multiple features
+        filter.addFeature(PhoneNumberFeature.VOICE);
+        assertEquals(EnumSet.of(PhoneNumberFeature.SMS, PhoneNumberFeature.VOICE), filter.getFeatures());
+
+        // Test shouldn't have more than one of each
+        filter.addFeature(PhoneNumberFeature.SMS);
+        assertEquals(EnumSet.of(PhoneNumberFeature.SMS, PhoneNumberFeature.VOICE), filter.getFeatures());
+
+        filter.addFeature(PhoneNumberFeature.MMS);
+        assertEquals(EnumSet.of(PhoneNumberFeature.SMS, PhoneNumberFeature.VOICE, PhoneNumberFeature.MMS), filter.getFeatures());
+    }
+
+    @Test
+    public void testAddingMultipleFeatures() {
+        // Setup
+        PurchasedNumbersFilter filter = new PurchasedNumbersFilter();
+
+        assertEquals(EnumSet.noneOf(PhoneNumberFeature.class), filter.getFeatures());
+
+        // Test
+        filter.addFeature(PhoneNumberFeature.SMS, PhoneNumberFeature.VOICE);
+        assertEquals(EnumSet.of(PhoneNumberFeature.SMS, PhoneNumberFeature.VOICE), filter.getFeatures());
+    }
+
+    @Test
+    public void testRemovingFeatures() {
+        // Setup
+        PurchasedNumbersFilter filter = new PurchasedNumbersFilter();
+
+        // Test
+        filter.addFeature(PhoneNumberFeature.SMS, PhoneNumberFeature.MMS, PhoneNumberFeature.VOICE);
+        assertEquals(EnumSet.of(PhoneNumberFeature.SMS, PhoneNumberFeature.VOICE, PhoneNumberFeature.MMS), filter.getFeatures());
+
+        filter.removeFeature(PhoneNumberFeature.VOICE);
+        assertEquals(EnumSet.of(PhoneNumberFeature.SMS, PhoneNumberFeature.MMS), filter.getFeatures());
+
+        filter.removeFeature(PhoneNumberFeature.VOICE);
+        assertEquals(EnumSet.of(PhoneNumberFeature.SMS, PhoneNumberFeature.MMS), filter.getFeatures());
+
+        filter.removeFeature(PhoneNumberFeature.SMS, PhoneNumberFeature.MMS);
+        assertEquals(EnumSet.noneOf(PhoneNumberFeature.class), filter.getFeatures());
+    }
+
+    @Test
+    public void testAddingTags() {
+        // Setup
+        PurchasedNumbersFilter filter = new PurchasedNumbersFilter();
+
+        assertArrayEquals(new String[]{}, filter.getTags().toArray());
+
+        // Test
+        filter.addTag("TEST_TAG");
+        assertArrayEquals(new String[]{"TEST_TAG"}, filter.getTags().toArray());
+
+        filter.addTag("Another test tag");
+        assertArrayEquals(new String[]{"TEST_TAG", "Another test tag"}, filter.getTags().toArray());
+
+        filter.addTag("a", "b", "c");
+        assertArrayEquals(new String[]{"TEST_TAG", "Another test tag", "a", "b", "c"}, filter.getTags().toArray());
+    }
+
+    @Test
+    public void testAddingDuplicateTags() {
+        // Setup
+        PurchasedNumbersFilter filter = new PurchasedNumbersFilter();
+
+        filter.addTag("a");
+        filter.addTag("a");
+        filter.addTag("a", "b", "b", "c", "b");
+
+        assertArrayEquals(new String[]{"a", "b", "c"}, filter.getTags().toArray());
+    }
+
+    @Test
+    public void testRemoveTags() {
+        // Setup
+        PurchasedNumbersFilter filter = new PurchasedNumbersFilter();
+
+        filter.addTag("a", "b", "c", "d");
+        assertArrayEquals(new String[]{"a", "b", "c", "d"}, filter.getTags().toArray());
+
+        // Test
+        filter.removeTag("b");
+        assertArrayEquals(new String[]{"a", "c", "d"}, filter.getTags().toArray());
+
+        filter.removeTag("d");
+        assertArrayEquals(new String[]{"a", "c"}, filter.getTags().toArray());
+
+        filter.removeTag("b", "c", "d");
+        assertArrayEquals(new String[]{"a"}, filter.getTags().toArray());
+    }
+
+    @Test
+    public void testClearTags() {
+        // Setup
+        PurchasedNumbersFilter filter = new PurchasedNumbersFilter();
+
+        filter.addTag("a", "b", "c", "d");
+        assertArrayEquals(new String[]{"a", "b", "c", "d"}, filter.getTags().toArray());
+
+        // Test
+        filter.clearTags();
+        assertArrayEquals(new String[]{}, filter.getTags().toArray());
+    }
+
+    @Test
+    public void testBasicSetters() {
+        // Setup
+        PurchasedNumbersFilter filter = new PurchasedNumbersFilter();
+
+        assertNull(filter.getNumber());
+        assertNull(filter.getRegion());
+        assertNull(filter.getLocality());
+        assertNull(filter.getType());
+
+        // Test
+        filter.setLimit(23);
+        filter.setOffset(5);
+        filter.setNumber("TEST_NUMBER");
+        filter.setRegion("TEST_REGION");
+        filter.setLocality("TEST_LOCALITY");
+        filter.setType(PhoneNumberType.MOBILE);
+
+        assertEquals(23, filter.getLimit());
+        assertEquals(5, filter.getOffset());
+        assertEquals("TEST_NUMBER", filter.getNumber());
+        assertEquals("TEST_REGION", filter.getRegion());
+        assertEquals("TEST_LOCALITY", filter.getLocality());
+        assertEquals(PhoneNumberType.MOBILE, filter.getType());
+    }
+
+    @Test
+    public void testToHashMapWithDefaultValues() throws GeneralException {
+        // Setup
+        PurchasedNumbersFilter filter = new PurchasedNumbersFilter();
+
+        HashMap<String, Object> map = filter.toHashMap();
+
+        assertEquals(10, map.get("limit"));
+        assertEquals(0, map.get("offset"));
+        assertEquals(EnumSet.noneOf(PhoneNumberFeature.class), map.get("features"));
+        assertEquals(new ArrayList<String>(), map.get("tags"));
+    }
+
+    @Test
+    public void testToHashMapWithAllValues() throws GeneralException {
+        // Setup
+        PurchasedNumbersFilter filter = new PurchasedNumbersFilter();
+
+        filter.setLimit(42);
+        filter.setOffset(24);
+        filter.setNumber("1234567890");
+        filter.setRegion("My Region");
+        filter.setLocality("My Locality");
+        filter.setType(PhoneNumberType.MOBILE);
+        filter.addFeature(PhoneNumberFeature.SMS, PhoneNumberFeature.VOICE);
+        filter.addTag("h", "e", "l", "l", "o");
+
+        HashMap<String, Object> map = filter.toHashMap();
+
+        assertEquals(42, map.get("limit"));
+        assertEquals(24, map.get("offset"));
+        assertEquals("1234567890", map.get("number"));
+        assertEquals("My Region", map.get("region"));
+        assertEquals("My Locality", map.get("locality"));
+        assertEquals("mobile", map.get("type").toString());
+        assertArrayEquals(new PhoneNumberFeature[]{PhoneNumberFeature.SMS, PhoneNumberFeature.VOICE}, ((Collection<Object>) map.get("features")).toArray());
+
+        assertArrayEquals(new String[]{"h", "e", "l", "o"}, ((Collection<Object>) map.get("tags")).toArray());
+    }
+}

--- a/api/src/test/java/com/messagebird/PurchasedNumbersFilterTest.java
+++ b/api/src/test/java/com/messagebird/PurchasedNumbersFilterTest.java
@@ -1,11 +1,9 @@
 package com.messagebird;
 
 import com.messagebird.exceptions.GeneralException;
-import com.messagebird.exceptions.UnauthorizedException;
 import com.messagebird.objects.*;
 import org.junit.Test;
 
-import java.lang.reflect.Array;
 import java.util.*;
 
 import static org.junit.Assert.*;

--- a/examples/src/main/java/ExampleCancelNumber.java
+++ b/examples/src/main/java/ExampleCancelNumber.java
@@ -1,0 +1,30 @@
+import com.messagebird.MessageBirdClient;
+import com.messagebird.MessageBirdService;
+import com.messagebird.MessageBirdServiceImpl;
+import com.messagebird.exceptions.GeneralException;
+import com.messagebird.exceptions.UnauthorizedException;
+import com.messagebird.exceptions.NotFoundException;
+
+public class ExampleCancelNumber {
+    public static void main(String[] args) {
+        if (args.length < 2) {
+            System.out.println("Please specify your access key & the number you wish to delete.");
+            return;
+        }
+        // First create your service object
+        final MessageBirdService wsr = new MessageBirdServiceImpl(args[0]);
+
+        // Add the service to the client
+        final MessageBirdClient messageBirdClient = new MessageBirdClient(wsr);
+        
+        try {
+            messageBirdClient.cancelNumber(args[1]);
+            System.out.println("Number Deleted!");
+        } catch (UnauthorizedException | GeneralException | NotFoundException exception) {
+            if (exception.getErrors() != null) {
+                System.out.println(exception.getErrors().toString());
+            }
+            exception.printStackTrace();
+        }
+    }
+}

--- a/examples/src/main/java/ExampleListNumbersForPurchase.java
+++ b/examples/src/main/java/ExampleListNumbersForPurchase.java
@@ -11,8 +11,8 @@ import com.messagebird.objects.PhoneNumbersLookup;
 
 public class ExampleListNumbersForPurchase {
     public static void main(String[] args) {
-        if (args.length < 1) {
-            System.out.println("Please specify your access key.");
+        if (args.length < 2) {
+            System.out.println("Please specify your access key and a country code to test.");
             return;
         }
         // First create your service object
@@ -22,7 +22,7 @@ public class ExampleListNumbersForPurchase {
         final MessageBirdClient messageBirdClient = new MessageBirdClient(wsr);
         
         try {
-            if (args.length > 1) {
+            if (args.length > 2) {
                 PhoneNumbersLookup options = new PhoneNumbersLookup();
                 options.setFeatures(PhoneNumberFeature.VOICE, PhoneNumberFeature.SMS);
                 options.setType(PhoneNumberType.MOBILE);
@@ -32,7 +32,7 @@ public class ExampleListNumbersForPurchase {
                 System.out.print(options.toString());
                 System.out.println(String.format("Request Made With Params: %s", messageBirdClient.listNumbersForPurchase("US", options)));
             } else {
-                System.out.println(String.format("Request Made Without Params: %s", messageBirdClient.listNumbersForPurchase("NL")));
+                System.out.println(String.format("Request Made Without Params: %s", messageBirdClient.listNumbersForPurchase(args[1])));
             }
         } catch (UnauthorizedException | GeneralException | NotFoundException exception) {
             if (exception.getErrors() != null) {

--- a/examples/src/main/java/ExampleListNumbersForPurchase.java
+++ b/examples/src/main/java/ExampleListNumbersForPurchase.java
@@ -4,6 +4,12 @@ import com.messagebird.MessageBirdServiceImpl;
 import com.messagebird.exceptions.GeneralException;
 import com.messagebird.exceptions.NotFoundException;
 import com.messagebird.exceptions.UnauthorizedException;
+import com.messagebird.objects.PhoneNumberFeature;
+import com.messagebird.objects.PhoneNumberType;
+import com.messagebird.objects.PhoneNumberSearchPattern;
+import com.messagebird.objects.PhoneNumbersLookup;
+
+import java.util.EnumSet;;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -15,17 +21,27 @@ public class ExampleListNumbersForPurchase {
             return;
         }
         // First create your service object
-        final MessageBirdService wsr = new MessageBirdServiceImpl(args[0], "https://numbers.messagebird.com");
+        final MessageBirdService wsr = new MessageBirdServiceImpl(args[0]);
 
         // Add the service to the client
         final MessageBirdClient messageBirdClient = new MessageBirdClient(wsr);
         
         try {
-            System.out.println(messageBirdClient.listNumbersForPurchase(args[1]));
-            return;
+            if (args[1].equalsIgnoreCase("--params")) {
+                PhoneNumbersLookup options = new PhoneNumbersLookup();
+                options.setFeatures(EnumSet.of(PhoneNumberFeature.VOICE, PhoneNumberFeature.SMS));
+                options.setType(PhoneNumberType.MOBILE);
+                options.setLimit(10);
+                options.setNumber(562);
+                options.setSearchPattern(PhoneNumberSearchPattern.START);
+                System.out.print(options.toString());
+                System.out.println(String.format("Request Made With Params: %s", messageBirdClient.listNumbersForPurchase("US", options)));
+            } else {
+                System.out.println(String.format("Request Made Without Params: %s", messageBirdClient.listNumbersForPurchase("NL")));
+            }
         } catch (UnauthorizedException | GeneralException | NotFoundException exception) {
             if (exception.getErrors() != null) {
-                System.out.println(exception.getErrors().toString());
+               System.out.println(exception.getErrors().toString());
             }
             exception.printStackTrace();
         }

--- a/examples/src/main/java/ExampleListNumbersForPurchase.java
+++ b/examples/src/main/java/ExampleListNumbersForPurchase.java
@@ -9,11 +9,6 @@ import com.messagebird.objects.PhoneNumberType;
 import com.messagebird.objects.PhoneNumberSearchPattern;
 import com.messagebird.objects.PhoneNumbersLookup;
 
-import java.util.EnumSet;;
-
-import java.util.LinkedHashMap;
-import java.util.Map;
-
 public class ExampleListNumbersForPurchase {
     public static void main(String[] args) {
         if (args.length < 1) {
@@ -29,7 +24,7 @@ public class ExampleListNumbersForPurchase {
         try {
             if (args.length > 1) {
                 PhoneNumbersLookup options = new PhoneNumbersLookup();
-                options.setFeatures(EnumSet.of(PhoneNumberFeature.VOICE, PhoneNumberFeature.SMS));
+                options.setFeatures(PhoneNumberFeature.VOICE, PhoneNumberFeature.SMS);
                 options.setType(PhoneNumberType.MOBILE);
                 options.setLimit(10);
                 options.setNumber(562);

--- a/examples/src/main/java/ExampleListNumbersForPurchase.java
+++ b/examples/src/main/java/ExampleListNumbersForPurchase.java
@@ -1,0 +1,30 @@
+import com.messagebird.MessageBirdClient;
+import com.messagebird.MessageBirdService;
+import com.messagebird.MessageBirdServiceImpl;
+import com.messagebird.exceptions.GeneralException;
+import com.messagebird.exceptions.NotFoundException;
+import com.messagebird.exceptions.UnauthorizedException;
+
+public class ExampleListNumbersForPurchase {
+    public static void main(String[] args) {
+        if (args.length < 1) {
+            System.out.println("Please specify your access key.");
+            return;
+        }
+        // First create your service object
+        final MessageBirdService wsr = new MessageBirdServiceImpl(args[0], "https://numbers.messagebird.com");
+
+        // Add the service to the client
+        final MessageBirdClient messageBirdClient = new MessageBirdClient(wsr);
+        
+        try {
+            System.out.println(messageBirdClient.listNumbersForPurchase(args[1]));
+            return;
+        } catch (UnauthorizedException | GeneralException | NotFoundException exception) {
+            if (exception.getErrors() != null) {
+                System.out.println(exception.getErrors().toString());
+            }
+            exception.printStackTrace();
+        }
+    }
+}

--- a/examples/src/main/java/ExampleListNumbersForPurchase.java
+++ b/examples/src/main/java/ExampleListNumbersForPurchase.java
@@ -27,7 +27,7 @@ public class ExampleListNumbersForPurchase {
         final MessageBirdClient messageBirdClient = new MessageBirdClient(wsr);
         
         try {
-            if (args[1].equalsIgnoreCase("--params")) {
+            if (args.length > 1) {
                 PhoneNumbersLookup options = new PhoneNumbersLookup();
                 options.setFeatures(EnumSet.of(PhoneNumberFeature.VOICE, PhoneNumberFeature.SMS));
                 options.setType(PhoneNumberType.MOBILE);

--- a/examples/src/main/java/ExampleListPurchasedNumbers.java
+++ b/examples/src/main/java/ExampleListPurchasedNumbers.java
@@ -2,13 +2,16 @@ import com.messagebird.MessageBirdClient;
 import com.messagebird.MessageBirdService;
 import com.messagebird.MessageBirdServiceImpl;
 import com.messagebird.exceptions.GeneralException;
+import com.messagebird.exceptions.NotFoundException;
 import com.messagebird.exceptions.UnauthorizedException;
-import com.messagebird.objects.PurchasedNumberCreatedResponse;
+import com.messagebird.objects.PhoneNumberFeature;
+import com.messagebird.objects.PhoneNumberType;
+import com.messagebird.objects.PurchasedNumbersFilter;
 
-public class ExamplePurchaseNumber {
+public class ExampleListPurchasedNumbers {
     public static void main(String[] args) {
-        if (args.length < 4) {
-            System.out.println("Please specify your access key, number, country code and billing interval months, eg: ExamplePurchaseNumber test_accesskey 3197010240563 NL 1");
+        if (args.length < 1) {
+            System.out.println("Please specify your access key.");
             return;
         }
         // First create your service object
@@ -16,13 +19,18 @@ public class ExamplePurchaseNumber {
 
         // Add the service to the client
         final MessageBirdClient messageBirdClient = new MessageBirdClient(wsr);
-        
-        try {
-            PurchasedNumberCreatedResponse purchasedNumberCreatedResponse = messageBirdClient.purchaseNumber(args[1], args[2], Integer.parseInt(args[3]));
 
-            System.out.println(purchasedNumberCreatedResponse);
+        PurchasedNumbersFilter filter = new PurchasedNumbersFilter();
+
+        filter.addFeature(PhoneNumberFeature.SMS);
+        filter.setType(PhoneNumberType.MOBILE);
+
+        filter.setLimit(25);
+
+        try {
+            System.out.println(messageBirdClient.listPurchasedNumbers(filter));
             return;
-        } catch (UnauthorizedException | GeneralException exception) {
+        } catch (UnauthorizedException | NotFoundException | GeneralException exception) {
             if (exception.getErrors() != null) {
                 System.out.println(exception.getErrors().toString());
             }

--- a/examples/src/main/java/ExampleListPurchasedNumbers.java
+++ b/examples/src/main/java/ExampleListPurchasedNumbers.java
@@ -5,7 +5,6 @@ import com.messagebird.exceptions.GeneralException;
 import com.messagebird.exceptions.NotFoundException;
 import com.messagebird.exceptions.UnauthorizedException;
 import com.messagebird.objects.PhoneNumberFeature;
-import com.messagebird.objects.PhoneNumberType;
 import com.messagebird.objects.PurchasedNumbersFilter;
 
 public class ExampleListPurchasedNumbers {
@@ -15,16 +14,12 @@ public class ExampleListPurchasedNumbers {
             return;
         }
         // First create your service object
-        final MessageBirdService wsr = new MessageBirdServiceImpl(args[0], "https://numbers.messagebird.com");
+        final MessageBirdService wsr = new MessageBirdServiceImpl(args[0]);
 
         // Add the service to the client
         final MessageBirdClient messageBirdClient = new MessageBirdClient(wsr);
 
         PurchasedNumbersFilter filter = new PurchasedNumbersFilter();
-
-        filter.addFeature(PhoneNumberFeature.SMS);
-        filter.setType(PhoneNumberType.MOBILE);
-
         filter.setLimit(25);
 
         try {

--- a/examples/src/main/java/ExampleListPurchasedNumbers.java
+++ b/examples/src/main/java/ExampleListPurchasedNumbers.java
@@ -29,7 +29,6 @@ public class ExampleListPurchasedNumbers {
 
         try {
             System.out.println(messageBirdClient.listPurchasedNumbers(filter));
-            return;
         } catch (UnauthorizedException | NotFoundException | GeneralException exception) {
             if (exception.getErrors() != null) {
                 System.out.println(exception.getErrors().toString());

--- a/examples/src/main/java/ExamplePurchaseNumber.java
+++ b/examples/src/main/java/ExamplePurchaseNumber.java
@@ -21,7 +21,6 @@ public class ExamplePurchaseNumber {
             PurchasedNumberCreatedResponse purchasedNumberCreatedResponse = messageBirdClient.purchaseNumber(args[1], args[2], Integer.parseInt(args[3]));
 
             System.out.println(purchasedNumberCreatedResponse);
-            return;
         } catch (UnauthorizedException | GeneralException exception) {
             if (exception.getErrors() != null) {
                 System.out.println(exception.getErrors().toString());

--- a/examples/src/main/java/ExamplePurchaseNumber.java
+++ b/examples/src/main/java/ExamplePurchaseNumber.java
@@ -4,14 +4,14 @@ import com.messagebird.MessageBirdServiceImpl;
 import com.messagebird.exceptions.GeneralException;
 import com.messagebird.exceptions.NotFoundException;
 import com.messagebird.exceptions.UnauthorizedException;
+import com.messagebird.objects.PurchasedPhoneNumber;
 
 import java.util.LinkedHashMap;
-import java.util.Map;
 
-public class ExampleListNumbersForPurchase {
+public class ExamplePurchaseNumber {
     public static void main(String[] args) {
-        if (args.length < 1) {
-            System.out.println("Please specify your access key.");
+        if (args.length < 4) {
+            System.out.println("Please specify your access key, number, country code and billing interval months, eg: ExamplePurchaseNumber test_accesskey 3197010240563 NL 1");
             return;
         }
         // First create your service object
@@ -21,9 +21,11 @@ public class ExampleListNumbersForPurchase {
         final MessageBirdClient messageBirdClient = new MessageBirdClient(wsr);
         
         try {
-            System.out.println(messageBirdClient.listNumbersForPurchase(args[1]));
+            PurchasedPhoneNumber purchasedPhoneNumber = messageBirdClient.purchaseNumber(args[1], args[2], Integer.parseInt(args[3]));
+
+            System.out.println(purchasedPhoneNumber);
             return;
-        } catch (UnauthorizedException | GeneralException | NotFoundException exception) {
+        } catch (UnauthorizedException | GeneralException exception) {
             if (exception.getErrors() != null) {
                 System.out.println(exception.getErrors().toString());
             }

--- a/examples/src/main/java/ExampleUpdateNumber.java
+++ b/examples/src/main/java/ExampleUpdateNumber.java
@@ -1,0 +1,27 @@
+import com.messagebird.MessageBirdClient;
+import com.messagebird.MessageBirdService;
+import com.messagebird.MessageBirdServiceImpl;
+import com.messagebird.exceptions.GeneralException;
+import com.messagebird.exceptions.UnauthorizedException;
+
+public class ExampleUpdateNumber {
+    public static void main(String[] args) {
+        if (args.length < 3) {
+            System.out.println("Please specify your access key, phone number, and the tags you wish to apply to it.");
+            return;
+        }
+        // First create your service object
+        final MessageBirdService wsr = new MessageBirdServiceImpl(args[0]);
+
+        // Add the service to the client
+        final MessageBirdClient messageBirdClient = new MessageBirdClient(wsr);
+        try {
+            System.out.println(messageBirdClient.updateNumber(args[1], args[2], args[3], args[4]));
+        } catch (UnauthorizedException | GeneralException exception) {
+            if (exception.getErrors() != null) {
+               System.out.println(exception.getErrors().toString());
+            }
+            exception.printStackTrace();
+        }
+    }
+}

--- a/examples/src/main/java/ExampleViewPurchasedNumber.java
+++ b/examples/src/main/java/ExampleViewPurchasedNumber.java
@@ -19,7 +19,6 @@ public class ExampleViewPurchasedNumber {
 
         try {
             System.out.println(messageBirdClient.viewPurchasedNumber(args[1]));
-            return;
         } catch (UnauthorizedException | NotFoundException | GeneralException exception) {
             if (exception.getErrors() != null) {
                 System.out.println(exception.getErrors().toString());

--- a/examples/src/main/java/ExampleViewPurchasedNumber.java
+++ b/examples/src/main/java/ExampleViewPurchasedNumber.java
@@ -2,13 +2,16 @@ import com.messagebird.MessageBirdClient;
 import com.messagebird.MessageBirdService;
 import com.messagebird.MessageBirdServiceImpl;
 import com.messagebird.exceptions.GeneralException;
+import com.messagebird.exceptions.NotFoundException;
 import com.messagebird.exceptions.UnauthorizedException;
-import com.messagebird.objects.PurchasedNumberCreatedResponse;
+import com.messagebird.objects.PhoneNumberFeature;
+import com.messagebird.objects.PhoneNumberType;
+import com.messagebird.objects.PurchasedNumbersFilter;
 
-public class ExamplePurchaseNumber {
+public class ExampleViewPurchasedNumber {
     public static void main(String[] args) {
-        if (args.length < 4) {
-            System.out.println("Please specify your access key, number, country code and billing interval months, eg: ExamplePurchaseNumber test_accesskey 3197010240563 NL 1");
+        if (args.length < 2) {
+            System.out.println("Please specify your access key and phone number.");
             return;
         }
         // First create your service object
@@ -16,13 +19,11 @@ public class ExamplePurchaseNumber {
 
         // Add the service to the client
         final MessageBirdClient messageBirdClient = new MessageBirdClient(wsr);
-        
-        try {
-            PurchasedNumberCreatedResponse purchasedNumberCreatedResponse = messageBirdClient.purchaseNumber(args[1], args[2], Integer.parseInt(args[3]));
 
-            System.out.println(purchasedNumberCreatedResponse);
+        try {
+            System.out.println(messageBirdClient.viewPurchasedNumber(args[1]));
             return;
-        } catch (UnauthorizedException | GeneralException exception) {
+        } catch (UnauthorizedException | NotFoundException | GeneralException exception) {
             if (exception.getErrors() != null) {
                 System.out.println(exception.getErrors().toString());
             }

--- a/examples/src/main/java/ExampleViewPurchasedNumber.java
+++ b/examples/src/main/java/ExampleViewPurchasedNumber.java
@@ -4,9 +4,6 @@ import com.messagebird.MessageBirdServiceImpl;
 import com.messagebird.exceptions.GeneralException;
 import com.messagebird.exceptions.NotFoundException;
 import com.messagebird.exceptions.UnauthorizedException;
-import com.messagebird.objects.PhoneNumberFeature;
-import com.messagebird.objects.PhoneNumberType;
-import com.messagebird.objects.PurchasedNumbersFilter;
 
 public class ExampleViewPurchasedNumber {
     public static void main(String[] args) {


### PR DESCRIPTION
1. Adds methods that allow for the following API Features:

- Searching phone numbers available for purchase (#75)
- Purchasing a phone number
- Fetching all purchased phone numbers
- Fetching a purchased phone number
- Updating a purchased phone number
- Cancel a purchased phone number

2. Fixes an issue with the `getPathVariables` method which, because it uses a Map, didn't allow for query string parameters that are arrays.
