### PR TITLE
added price field on message response #Issue_143

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -108,6 +108,11 @@
             <version>2.21.0</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jetbrains</groupId>
+            <artifactId>annotations</artifactId>
+            <version>13.0</version>
+        </dependency>
     </dependencies>
 
     <distributionManagement>

--- a/api/src/main/java/com/messagebird/objects/MessageResponse.java
+++ b/api/src/main/java/com/messagebird/objects/MessageResponse.java
@@ -1,5 +1,7 @@
 package com.messagebird.objects;
 
+import com.sun.istack.internal.Nullable;
+
 import java.io.Serializable;
 import java.math.BigInteger;
 import java.util.Date;
@@ -260,6 +262,8 @@ public class MessageResponse implements MessageResponseBase, Serializable {
         private BigInteger recipient;
         private String status;
         private Date statusDatetime;
+        @Nullable
+        private Price price;
 
         public Items() {
         }
@@ -270,6 +274,7 @@ public class MessageResponse implements MessageResponseBase, Serializable {
                     "recipient=" + recipient +
                     ", status='" + status + '\'' +
                     ", statusDatetime=" + statusDatetime +
+                    ", price=" + price +
                     "}";
         }
 
@@ -298,6 +303,41 @@ public class MessageResponse implements MessageResponseBase, Serializable {
          */
         public Date getStatusDatetime() {
             return statusDatetime;
+        }
+
+        public Price getPrice() {
+            return price;
+        }
+
+    }
+
+    /**
+     * Response price of items
+     */
+    static public class Price implements Serializable {
+
+        private static final long serialVersionUID = -4104837036540050532L;
+
+        private float amount;
+        private String currency;
+
+        public Price() {
+        }
+
+        @Override
+        public String toString() {
+            return "Price{" +
+                    "amount=" + amount +
+                    ", currency=" + currency +
+                    "}";
+        }
+
+        public float getAmount() {
+            return amount;
+        }
+
+        public String getCurrency() {
+            return currency;
         }
 
     }

--- a/api/src/main/java/com/messagebird/objects/MessageResponse.java
+++ b/api/src/main/java/com/messagebird/objects/MessageResponse.java
@@ -1,6 +1,6 @@
 package com.messagebird.objects;
 
-import com.sun.istack.internal.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.Serializable;
 import java.math.BigInteger;


### PR DESCRIPTION
Price field added on message response as nullable because the price response is null if the message isn’t billed yet.
Scenarios are tested with ExampleSendMessage and ExampleViewMessage. 