### PR TITLE
Make JetBrains annotations "provided" to avoid runtime transitive dep…

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -117,6 +117,7 @@
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
             <version>13.0</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
…endency

These are annotations used for static analysis at development time only and not needed at runtime