### PR TITLE
added video enum on TemplateMediaType

### DIFF
--- a/api/src/main/java/com/messagebird/objects/conversations/TemplateMediaType.java
+++ b/api/src/main/java/com/messagebird/objects/conversations/TemplateMediaType.java
@@ -7,6 +7,7 @@ public enum TemplateMediaType {
 
     IMAGE("image"),
     DOCUMENT("document"),
+    VIDEO("video"),
     TEXT("text"),
     CURRENCY("currency"),
     DATETIME("date_time"),


### PR DESCRIPTION
A customer wants to use the Conversations API (Rest) to get a message including the video using the template 
they defined. Thus, the video type is missing on TemplateMediaType, I add the missing enum on this PR.
Can you review it when you have time? @olimpias 