### PR TITLE
upgrade jackson databind lib version

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -88,7 +88,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.13.2.2</version>
+            <version>2.14.0-rc1</version>
         </dependency>
         <dependency>
             <groupId>com.auth0</groupId>


### PR DESCRIPTION
upgraded Jackson Databind lib version for security vulnerability reasons. [[CVE-2022-42003](https://nvd.nist.gov/vuln/detail/CVE-2022-42003)] 