### PR TITLE
Make `MessageBirdClient#getVerifyObject` public

### DIFF
--- a/api/src/main/java/com/messagebird/MessageBirdClient.java
+++ b/api/src/main/java/com/messagebird/MessageBirdClient.java
@@ -470,7 +470,7 @@ public class MessageBirdClient {
      * @throws UnauthorizedException if client is unauthorized
      * @throws GeneralException      general exception
      */
-    Verify getVerifyObject(String id) throws NotFoundException, GeneralException, UnauthorizedException {
+    public Verify getVerifyObject(String id) throws NotFoundException, GeneralException, UnauthorizedException {
         if (id == null || id.isEmpty()) {
             throw new IllegalArgumentException("ID cannot be empty for verify");
         }


### PR DESCRIPTION
Hello!

We have a use case where we'd like to inspect existing `Verify` objects, but it looks like there's no public accessor for existing `Verify` objects in `MessageBirdClient`. There _is_ a package-private getter, though, and it'd be great if we could make that public.

Thanks!