### PR TITLE
Represent prices as `BigDecimal`

### DIFF
--- a/api/src/main/java/com/messagebird/objects/MessageResponse.java
+++ b/api/src/main/java/com/messagebird/objects/MessageResponse.java
@@ -3,6 +3,7 @@ package com.messagebird.objects;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.Serializable;
+import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Date;
 import java.util.List;
@@ -382,7 +383,7 @@ public class MessageResponse implements MessageResponseBase, Serializable {
 
         private static final long serialVersionUID = -4104837036540050532L;
 
-        private float amount;
+        private BigDecimal amount;
         private String currency;
 
         public Price() {
@@ -397,6 +398,10 @@ public class MessageResponse implements MessageResponseBase, Serializable {
         }
 
         public float getAmount() {
+            return amount.floatValue();
+        }
+
+        public BigDecimal getAmountDecimal() {
             return amount;
         }
 


### PR DESCRIPTION
The MessageBird API transmits prices as floating point literals rather than arbitrary-precision decimal numbers. This can lead to [loss-of-precision issues](https://dzone.com/articles/never-use-float-and-double-for-monetary-calculatio) down the line. For example, consider this (real-world!) API response:

```json
{
  "price": {
    "amount": 0.0018,
    "currency": "USD"
  },
}
```

If we try to convert the `price` above into a [Joda Money](https://www.joda.org/joda-money/) `Money` instance (again, just as an example), then we run into:

```
java.lang.ArithmeticException: Scale of amount 0.0017999999690800905 is greater than the scale of the currency USD
```

While I think it might be wise to transmit the price as a string at the API level, I think there are also things we can do in the client library to help. This pull request, for example, parses the price as a `BigDecimal`. It preserves the return type of the existing `Price#getAmount()` method, but introduces a `Price#getAmountDecimal()` method that returns the `BigDecimal` representation (ideally without loss of precision).

Although it's beyond the scope of this pull request, if the upstream API response were to change to something like this:

```json
{
  "price": {
    "amount": 0.0018,
    "amountDecimal": "0.0018",
    "currency": "USD"
  },
}
```

…then this change would be forward-compatible from a Java binary perspective, too.