### PR TITLE
Add support for fetching outbound SMS prices

### DIFF
--- a/api/src/main/java/com/messagebird/MessageBirdClient.java
+++ b/api/src/main/java/com/messagebird/MessageBirdClient.java
@@ -2234,6 +2234,10 @@ public class MessageBirdClient {
      * @see <a href="https://developers.messagebird.com/quickstarts/pricingapi/list-outbound-sms-prices/">Pricing API</a>
      */
     public OutboundSmsPriceResponse getOutboundSmsPrices(final String smppUsername) throws GeneralException, UnauthorizedException, NotFoundException {
+        if (smppUsername == null) {
+            throw new IllegalArgumentException("SMPP username must be specified.");
+        }
+
         final String url = String.format(OUTBOUND_SMS_PRICING_SMPP_PATH, smppUsername);
         return messageBirdService.request(url, OutboundSmsPriceResponse.class);
     }

--- a/api/src/main/java/com/messagebird/MessageBirdClient.java
+++ b/api/src/main/java/com/messagebird/MessageBirdClient.java
@@ -105,6 +105,8 @@ public class MessageBirdClient {
     private static final String VOICELEGS_SUFFIX_PATH = "/legs";
     static final String FILES_PATH = "/files";
     static final String TEMPLATES_PATH = "/templates";
+    static final String OUTBOUND_SMS_PRICING_PATH = "/pricing/sms/outbound";
+    static final String OUTBOUND_SMS_PRICING_SMPP_PATH = "/pricing/sms/outbound/smpp/%s";
 
     static final String RECORDING_DOWNLOAD_FORMAT = ".wav";
 
@@ -2201,5 +2203,38 @@ public class MessageBirdClient {
         String url = String.format("%s/child-accounts", PARTNER_ACCOUNTS_BASE_URL);
         System.out.println("url: " + url);
         messageBirdService.deleteByID(url, id);
+    }
+
+    /**
+     * Returns outbound pricing for the default SMS configuration for the authenticated account.
+     *
+     * @return outbound pricing for the default SMS configuration for the authenticated account
+     *
+     * @throws UnauthorizedException if client is unauthorized
+     * @throws GeneralException      general exception
+     * @throws NotFoundException     if pricing information could not be found
+     *
+     * @see <a href="https://developers.messagebird.com/quickstarts/pricingapi/list-outbound-sms-prices/">Pricing API</a>
+     */
+    public OutboundSmsPriceResponse getOutboundSmsPrices() throws GeneralException, UnauthorizedException, NotFoundException {
+        return messageBirdService.request(OUTBOUND_SMS_PRICING_PATH, OutboundSmsPriceResponse.class);
+    }
+
+    /**
+     * Returns outbound SMS pricing for a specific SMPP username.
+     *
+     * @param smppUsername the SMPP SystemID provided by MessageBird
+     *
+     * @return outbound SMS pricing for the given SMPP username
+     *
+     * @throws UnauthorizedException if client is unauthorized
+     * @throws GeneralException      general exception
+     * @throws NotFoundException     if pricing information could not be found for the given SMPP username
+     *
+     * @see <a href="https://developers.messagebird.com/quickstarts/pricingapi/list-outbound-sms-prices/">Pricing API</a>
+     */
+    public OutboundSmsPriceResponse getOutboundSmsPrices(final String smppUsername) throws GeneralException, UnauthorizedException, NotFoundException {
+        final String url = String.format(OUTBOUND_SMS_PRICING_SMPP_PATH, smppUsername);
+        return messageBirdService.request(url, OutboundSmsPriceResponse.class);
     }
 } 

--- a/api/src/main/java/com/messagebird/objects/OutboundSmsPrice.java
+++ b/api/src/main/java/com/messagebird/objects/OutboundSmsPrice.java
@@ -1,0 +1,60 @@
+package com.messagebird.objects;
+
+import java.math.BigDecimal;
+
+public class OutboundSmsPrice {
+    private BigDecimal price;
+    private String currencyCode;
+    private String mccmnc;
+    private String mcc;
+    private String mnc;
+    private String countryName;
+    private String countryIsoCode;
+    private String operatorName;
+
+    public BigDecimal getPrice() {
+        return price;
+    }
+
+    public String getCurrencyCode() {
+        return currencyCode;
+    }
+
+    public String getMccmnc() {
+        return mccmnc;
+    }
+
+    public String getMcc() {
+        return mcc;
+    }
+
+    public String getMnc() {
+        return mnc;
+    }
+
+    public String getCountryName() {
+        return countryName;
+    }
+
+    public String getCountryIsoCode() {
+        return countryIsoCode;
+    }
+
+    public String getOperatorName() {
+        return operatorName;
+    }
+
+    @Override
+    public String toString() {
+        return "OutboundSmsPrice{" +
+                "price=" + price +
+                ", currencyCode='" + currencyCode + '\'' +
+                ", mccmnc='" + mccmnc + '\'' +
+                ", mcc='" + mcc + '\'' +
+                ", mnc='" + mnc + '\'' +
+                ", countryName='" + countryName + '\'' +
+                ", countryIsoCode='" + countryIsoCode + '\'' +
+                ", operatorName='" + operatorName + '\'' +
+                '}';
+    }
+}

--- a/api/src/main/java/com/messagebird/objects/OutboundSmsPriceResponse.java
+++ b/api/src/main/java/com/messagebird/objects/OutboundSmsPriceResponse.java
@@ -1,0 +1,36 @@
+package com.messagebird.objects;
+
+import java.util.List;
+
+public class OutboundSmsPriceResponse {
+    private int gateway;
+    private String currencyCode;
+    private int totalCount;
+    private List<OutboundSmsPrice> prices;
+
+    public int getGateway() {
+        return gateway;
+    }
+
+    public String getCurrencyCode() {
+        return currencyCode;
+    }
+
+    public int getTotalCount() {
+        return totalCount;
+    }
+
+    public List<OutboundSmsPrice> getPrices() {
+        return prices;
+    }
+
+    @Override
+    public String toString() {
+        return "OutboundSmsPriceResponse{" +
+                "gateway=" + gateway +
+                ", currencyCode='" + currencyCode + '\'' +
+                ", totalCount=" + totalCount +
+                ", prices=" + prices +
+                '}';
+    }
+}

--- a/api/src/test/java/com/messagebird/OutboundSmsPricesTest.java
+++ b/api/src/test/java/com/messagebird/OutboundSmsPricesTest.java
@@ -11,6 +11,7 @@ import java.math.BigDecimal;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
 
 public class OutboundSmsPricesTest {
 
@@ -38,6 +39,11 @@ public class OutboundSmsPricesTest {
         MessageBirdClient messageBirdClient = new MessageBirdClient(messageBirdService);
 
         assertReceivedExpectedResponse(messageBirdClient.getOutboundSmsPrices("test-smpp-user"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testGetOutboundSmsPricesSmppUsernameNull() throws GeneralException, UnauthorizedException, NotFoundException {
+        new MessageBirdClient(mock(MessageBirdService.class)).getOutboundSmsPrices(null);
     }
 
     private static void assertReceivedExpectedResponse(OutboundSmsPriceResponse outboundSmsPriceResponse) {

--- a/api/src/test/java/com/messagebird/OutboundSmsPricesTest.java
+++ b/api/src/test/java/com/messagebird/OutboundSmsPricesTest.java
@@ -1,0 +1,77 @@
+package com.messagebird;
+
+import com.messagebird.exceptions.GeneralException;
+import com.messagebird.exceptions.NotFoundException;
+import com.messagebird.exceptions.UnauthorizedException;
+import com.messagebird.objects.OutboundSmsPriceResponse;
+import com.messagebird.util.Resources;
+import org.junit.Test;
+
+import java.math.BigDecimal;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class OutboundSmsPricesTest {
+
+    @Test
+    public void testGetOutboundSmsPrices() throws GeneralException, UnauthorizedException, NotFoundException {
+        String responseFixture = Resources.readResourceText("/fixtures/outbound_sms_prices.json");
+
+        MessageBirdService messageBirdService = SpyService
+                .expects("GET", "pricing/sms/outbound")
+                .withRestAPIBaseURL()
+                .andReturns(new APIResponse(responseFixture, 200));
+        MessageBirdClient messageBirdClient = new MessageBirdClient(messageBirdService);
+
+        assertReceivedExpectedResponse(messageBirdClient.getOutboundSmsPrices());
+    }
+
+    @Test
+    public void testGetOutboundSmsPricesSmppUsername() throws GeneralException, UnauthorizedException, NotFoundException {
+        String responseFixture = Resources.readResourceText("/fixtures/outbound_sms_prices.json");
+
+        MessageBirdService messageBirdService = SpyService
+                .expects("GET", "pricing/sms/outbound/smpp/test-smpp-user")
+                .withRestAPIBaseURL()
+                .andReturns(new APIResponse(responseFixture, 200));
+        MessageBirdClient messageBirdClient = new MessageBirdClient(messageBirdService);
+
+        assertReceivedExpectedResponse(messageBirdClient.getOutboundSmsPrices("test-smpp-user"));
+    }
+
+    private static void assertReceivedExpectedResponse(OutboundSmsPriceResponse outboundSmsPriceResponse) {
+        assertEquals(10, outboundSmsPriceResponse.getGateway());
+        assertEquals("EUR", outboundSmsPriceResponse.getCurrencyCode());
+        assertEquals(3, outboundSmsPriceResponse.getTotalCount());
+
+        assertEquals(3, outboundSmsPriceResponse.getPrices().size());
+
+        assertEquals(new BigDecimal("0.060000"), outboundSmsPriceResponse.getPrices().get(0).getPrice());
+        assertEquals("EUR", outboundSmsPriceResponse.getPrices().get(0).getCurrencyCode());
+        assertEquals("0", outboundSmsPriceResponse.getPrices().get(0).getMccmnc());
+        assertEquals("0", outboundSmsPriceResponse.getPrices().get(0).getMcc());
+        assertNull(outboundSmsPriceResponse.getPrices().get(0).getMnc());
+        assertEquals("Default Rate", outboundSmsPriceResponse.getPrices().get(0).getCountryName());
+        assertEquals("XX", outboundSmsPriceResponse.getPrices().get(0).getCountryIsoCode());
+        assertEquals("Default Rate", outboundSmsPriceResponse.getPrices().get(0).getOperatorName());
+
+        assertEquals(new BigDecimal("0.047000"), outboundSmsPriceResponse.getPrices().get(1).getPrice());
+        assertEquals("EUR", outboundSmsPriceResponse.getPrices().get(1).getCurrencyCode());
+        assertEquals("202", outboundSmsPriceResponse.getPrices().get(1).getMccmnc());
+        assertEquals("202", outboundSmsPriceResponse.getPrices().get(1).getMcc());
+        assertNull(outboundSmsPriceResponse.getPrices().get(1).getMnc());
+        assertEquals("Greece", outboundSmsPriceResponse.getPrices().get(1).getCountryName());
+        assertEquals("GR", outboundSmsPriceResponse.getPrices().get(1).getCountryIsoCode());
+        assertNull(outboundSmsPriceResponse.getPrices().get(1).getOperatorName());
+
+        assertEquals(new BigDecimal("0.045000"), outboundSmsPriceResponse.getPrices().get(2).getPrice());
+        assertEquals("EUR", outboundSmsPriceResponse.getPrices().get(2).getCurrencyCode());
+        assertEquals("20205", outboundSmsPriceResponse.getPrices().get(2).getMccmnc());
+        assertEquals("202", outboundSmsPriceResponse.getPrices().get(2).getMcc());
+        assertEquals("05", outboundSmsPriceResponse.getPrices().get(2).getMnc());
+        assertEquals("Greece", outboundSmsPriceResponse.getPrices().get(2).getCountryName());
+        assertEquals("GR", outboundSmsPriceResponse.getPrices().get(2).getCountryIsoCode());
+        assertEquals("Vodafone", outboundSmsPriceResponse.getPrices().get(2).getOperatorName());
+    }
+}

--- a/api/src/test/resources/fixtures/outbound_sms_prices.json
+++ b/api/src/test/resources/fixtures/outbound_sms_prices.json
@@ -1,0 +1,37 @@
+{
+  "gateway": 10,
+  "currencyCode": "EUR",
+  "totalCount": 3,
+  "prices": [
+    {
+      "price": "0.060000",
+      "currencyCode": "EUR",
+      "mccmnc": "0",
+      "mcc": "0",
+      "mnc": null,
+      "countryName": "Default Rate",
+      "countryIsoCode": "XX",
+      "operatorName": "Default Rate"
+    },
+    {
+      "price": "0.047000",
+      "currencyCode": "EUR",
+      "mccmnc": "202",
+      "mcc": "202",
+      "mnc": null,
+      "countryName": "Greece",
+      "countryIsoCode": "GR",
+      "operatorName": null
+    },
+    {
+      "price": "0.045000",
+      "currencyCode": "EUR",
+      "mccmnc": "20205",
+      "mcc": "202",
+      "mnc": "05",
+      "countryName": "Greece",
+      "countryIsoCode": "GR",
+      "operatorName": "Vodafone"
+    }
+  ]
+}

--- a/examples/src/main/java/ExampleGetOutboundSmsPrices.java
+++ b/examples/src/main/java/ExampleGetOutboundSmsPrices.java
@@ -1,0 +1,33 @@
+import com.messagebird.MessageBirdClient;
+import com.messagebird.MessageBirdServiceImpl;
+import com.messagebird.exceptions.MessageBirdException;
+import com.messagebird.objects.OutboundSmsPriceResponse;
+
+public class ExampleGetOutboundSmsPrices {
+
+    public static void main(String[] args) {
+        if (args.length != 1 && args.length != 2) {
+            System.out.println("Please specify your access key and (optionally) SMPP username");
+            return;
+        }
+
+        final MessageBirdClient messageBirdClient = new MessageBirdClient(new MessageBirdServiceImpl(args[0]));
+
+        try {
+            System.out.println("Get a list of outbound SMS prices");
+
+            final OutboundSmsPriceResponse outboundSmsPriceResponse;
+
+            if (args.length == 2) {
+                final String smppUsername = args[1];
+                outboundSmsPriceResponse = messageBirdClient.getOutboundSmsPrices(smppUsername);
+            } else {
+                outboundSmsPriceResponse = messageBirdClient.getOutboundSmsPrices();
+            }
+
+            System.out.println("response: " + outboundSmsPriceResponse);
+        } catch (MessageBirdException e) {
+            e.printStackTrace();
+        }
+    }
+}


### PR DESCRIPTION
This adds support for getting outbound SMS prices from the MessageBird API as described in the [Pricing API documentation](https://developers.messagebird.com/quickstarts/pricingapi/list-outbound-sms-prices/). I notice that the documentation is technically under "quickstarts," but I was unable to locate more canonical documentation under ["API reference."](https://developers.messagebird.com/api/#messagebird-api-reference) If there's a more appropriate set of documentation to link to, I'll happily adjust this pull request (and my own bookmarks)!