### PR TITLE
Fix java version parsing

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -93,6 +93,11 @@
             <version>3.17.0</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-artifact</artifactId>
+            <version>3.9.6</version>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.13.1</version>


### PR DESCRIPTION
Current implementation of parsing the Java version assumes that all Java versions returned by `System.getProperty("java.version")` will be in `MAJOR.MINOR.PATCH` format (e.g `21.0.2`), while this is incorrect.
This breaks on versions that do not follow this format - for example, [JDK 21+35](https://github.com/openjdk/jdk/releases/tag/jdk-21%2B35) returns `21`.
This is causing two issues:
- Inconsistent date formats across different versions that are all `> 1.6` - [here](https://github.com/messagebird/java-rest-api/blob/426dadeeaf3aecef6d2921aa6470920320806acd/api/src/main/java/com/messagebird/MessageBirdServiceImpl.java#L633-L645)
- Inconsistent `User-agent` header - [here](https://github.com/messagebird/java-rest-api/blob/426dadeeaf3aecef6d2921aa6470920320806acd/api/src/main/java/com/messagebird/MessageBirdServiceImpl.java#L91-L100)

This PR changes version parsing to use a versioning abstraction that is `Comparable` - I chose to use the existing implementation from `maven-artifacts`

I've tried to write some tests for this but to be honest I don't find the `MessageBirdServiceImpl` class very unit-testable, so I ended up not writing a unit test for this.