### PR TITLE
Update com.auth0:java-jwt to 4.4.0

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -90,7 +90,7 @@
         <dependency>
             <groupId>com.auth0</groupId>
             <artifactId>java-jwt</artifactId>
-            <version>3.17.0</version>
+            <version>4.4.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>

--- a/api/src/main/java/com/messagebird/RequestValidator.java
+++ b/api/src/main/java/com/messagebird/RequestValidator.java
@@ -5,13 +5,14 @@ import com.auth0.jwt.JWTVerifier.BaseVerification;
 import com.auth0.jwt.algorithms.Algorithm;
 import com.auth0.jwt.exceptions.JWTVerificationException;
 import com.auth0.jwt.exceptions.SignatureVerificationException;
-import com.auth0.jwt.interfaces.Clock;
+import com.auth0.jwt.interfaces.Claim;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import com.auth0.jwt.interfaces.JWTVerifier;
 import com.messagebird.exceptions.RequestValidationException;
 
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.time.Clock;
 
 /**
  * RequestValidator validates request signature signed by MessageBird services.
@@ -128,7 +129,8 @@ public class RequestValidator {
         if (!skipURLValidation)
             builder.withClaim("url_hash", calculateSha256(url.getBytes()));
 
-        boolean payloadHashClaimExist = !jwt.getClaim("payload_hash").isNull();
+        Claim payloadHashClaim = jwt.getClaim("payload_hash");
+        boolean payloadHashClaimExist = !(payloadHashClaim.isNull() || payloadHashClaim.isMissing());
         if (requestBody != null && requestBody.length > 0) {
             if (!payloadHashClaimExist) {
                 throw new RequestValidationException("The Claim 'payload_hash' is not set but payload is present.");

--- a/api/src/test/java/com/messagebird/RequestValidatorTest.java
+++ b/api/src/test/java/com/messagebird/RequestValidatorTest.java
@@ -1,6 +1,5 @@
 package com.messagebird;
 
-import com.auth0.jwt.interfaces.Clock;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.messagebird.exceptions.RequestValidationException;
@@ -13,7 +12,10 @@ import org.junit.runners.Parameterized.Parameters;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.time.Clock;
+import java.time.Instant;
 import java.time.OffsetDateTime;
+import java.time.ZoneId;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -64,10 +66,7 @@ public class RequestValidatorTest {
     public void testWebhookSignature() throws Throwable {
         RequestValidator validator = new RequestValidator(testCase.secret != null ? testCase.secret : "");
 
-        Clock clock = mock(Clock.class);
-        Date clockDate = spy(Date.from(OffsetDateTime.parse(testCase.timestamp).toInstant()));
-        when(clock.getToday()).thenReturn(clockDate);
-
+        Clock clock = Clock.fixed(OffsetDateTime.parse(testCase.timestamp).toInstant(), ZoneId.systemDefault());
         ThrowingRunnable runnable = () -> validator.validateSignature(clock, testCase.token, testCase.url,
                 (testCase.payload == null) ? null : testCase.payload.getBytes(StandardCharsets.UTF_8));
 


### PR DESCRIPTION
We have other library dependencies that recently updated to java-jwt 4.x. Unfortunately, the [breaking changes from v3 &rarr; v4](https://github.com/auth0/java-jwt/blob/fb6d00ad9773c6e7624c518feb2d06ed191287fa/MIGRATION_GUIDE.md#upgrading-from-v3x---v40) mean that all dependent usages need to be updated.
