### PR TITLE
Update to Jackson 2.14.2

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -76,16 +76,20 @@
         </profile>
     </profiles>
 
+    <properties>
+        <jackson.version>2.14.3</jackson.version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.13.2</version>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.14.0-rc1</version>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.auth0</groupId>


### PR DESCRIPTION
Note while most users will likely already have their managed version of Jackson provided, this at least makes it for users who don't avoid using the old release candidate version. Also aligns the jackson-annotations version. Didn't push the minor version forward because allow for the downstream consumer to decide what Jackson version they want as much as possible i.e. they can push it forward rather than forcing the dependency/avoid programming against newer Jackson minor features.