### PR TITLE
fix(deps): pin plexus-utils to 3.6.1 to resolve CVE-2025-67030

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -114,6 +114,17 @@
         </profile>
     </profiles>
 
+    <dependencyManagement>
+        <dependencies>
+            <!-- Pin patched plexus-utils (transitive via maven-artifact); fixes CVE-2025-67030. -->
+            <dependency>
+                <groupId>org.codehaus.plexus</groupId>
+                <artifactId>plexus-utils</artifactId>
+                <version>3.6.1</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
## Summary

`api/pom.xml` transitively pulls **`org.codehaus.plexus:plexus-utils:3.5.1`** via `org.apache.maven:maven-artifact:3.9.6`. That version is affected by **[CVE-2025-67030](https://github.com/advisories/GHSA-6fmv-xxpf-w3cw)** — a directory-traversal / "Zip Slip" flaw in `org.codehaus.plexus.util.Expand.extractFile()` (CWE-22, CVSS 8.8). Fixed in plexus-utils 3.6.1 / 4.0.3.

This PR adds a `dependencyManagement` pin forcing the patched **3.6.1**.

## Why this is safe (no expected regression)

- `maven-artifact` is used here only for `ComparableVersion` (a single JVM-version check in `MessageBirdServiceImpl`). `ComparableVersion` does not reference plexus-utils at all.
- Within `maven-artifact:3.9.6`, only `DefaultArtifact` touches plexus (one call: `StringUtils.isNotEmpty`), and `DefaultArtifact` is never used by this client — so plexus-utils is effectively never loaded at runtime. The vulnerable `Expand` class is not reachable.
- **3.6.1** stays on the 3.x line (same package layout; `StringUtils.isNotEmpty` unchanged), deliberately avoiding the `plexus-xml` split introduced in the 4.x line.

## Verification

- Before: `mvn -pl api dependency:tree` → `plexus-utils:jar:3.5.1:compile`
- After: → `plexus-utils:jar:3.6.1:compile`
- `mvn test` → all 130 unit tests pass (the 2 pre-existing `UnauthorizedException` errors are live integration tests requiring a real API access key, unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)