### PR TITLE
release: 6.3.1 — pin plexus-utils to 3.6.1 (CVE-2025-67030)

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -114,6 +114,17 @@
         </profile>
     </profiles>
 
+    <dependencyManagement>
+        <dependencies>
+            <!-- Pin patched plexus-utils (transitive via maven-artifact); fixes CVE-2025-67030. -->
+            <dependency>
+                <groupId>org.codehaus.plexus</groupId>
+                <artifactId>plexus-utils</artifactId>
+                <version>3.6.1</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
Releases **6.3.1** with a security fix.

## Fix — CVE-2025-67030

`api/pom.xml` transitively pulls **`org.codehaus.plexus:plexus-utils:3.5.1`** via `org.apache.maven:maven-artifact:3.9.6`, which is affected by **[CVE-2025-67030](https://github.com/advisories/GHSA-6fmv-xxpf-w3cw)** — a directory-traversal / "Zip Slip" flaw in `org.codehaus.plexus.util.Expand.extractFile()` (CWE-22, CVSS 8.8). Fixed in plexus-utils 3.6.1 / 4.0.3.

A `dependencyManagement` pin forces the patched **3.6.1**.

### Why this is safe (no expected regression)
- `maven-artifact` is used here only for `ComparableVersion` (a single JVM-version check). `ComparableVersion` does not reference plexus-utils at all.
- Within `maven-artifact:3.9.6`, only `DefaultArtifact` touches plexus (`StringUtils.isNotEmpty`), and it is never used by this client — so plexus-utils is effectively never loaded at runtime; the vulnerable `Expand` class is unreachable.
- 3.6.1 stays on the 3.x line (same package layout; `StringUtils.isNotEmpty` unchanged), avoiding the `plexus-xml` split introduced in 4.x.

## Release bump
- `messagebird-api` version `6.3.0` → `6.3.1`
- `clientVersion` (User-Agent) bumped to `6.3.1` to stay in sync

## Verification
- `dependency:tree`: `plexus-utils` `3.5.1` → `3.6.1`
- `mvn clean package` builds `messagebird-api-6.3.1.jar`; all 130 unit tests pass (2 pre-existing `UnauthorizedException` errors are live integration tests needing a real API key, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)