### PR TITLE
chore(release): bump version to 6.3.1

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.messagebird</groupId>
     <artifactId>messagebird-api</artifactId>
-    <version>6.3.0</version>
+    <version>6.3.1</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>

--- a/api/src/main/java/com/messagebird/MessageBirdServiceImpl.java
+++ b/api/src/main/java/com/messagebird/MessageBirdServiceImpl.java
@@ -72,7 +72,7 @@ public class MessageBirdServiceImpl implements MessageBirdService {
 
     private final String accessKey;
     private final String serviceUrl;
-    private final String clientVersion = "6.3.0";
+    private final String clientVersion = "6.3.1";
     private final String userAgentString;
     private Proxy proxy = null;
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.messagebird</groupId>
     <artifactId>examples</artifactId>
-    <version>6.2.5</version>
+    <version>6.3.1</version>
 
     <licenses>
         <license>
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>com.messagebird</groupId>
             <artifactId>messagebird-api</artifactId>
-            <version>6.2.5</version>
+            <version>6.3.1</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Follow-up to #281. That PR merged the CVE-2025-67030 fix but landed before the version-bump commit was included, so `master` still reads `6.3.0` (already published to Maven Central).

This bumps the release version so the fix can ship, updating every spot the release convention (see #275) touches:
- `api/pom.xml` — `messagebird-api` `6.3.0` → `6.3.1`
- `MessageBirdServiceImpl.java` — `clientVersion` (User-Agent) → `6.3.1`
- `examples/pom.xml` — module version **and** its `messagebird-api` dependency → `6.3.1` (was stale at `6.2.5`; missed in the 6.3.0 release)

After merge: tag `v6.3.1` and publish `6.3.1` to Maven Central.

🤖 Generated with [Claude Code](https://claude.com/claude-code)